### PR TITLE
Adding EscapeFilter function

### DIFF
--- a/ldap.go
+++ b/ldap.go
@@ -10,7 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"gopkg.in/asn1-ber.v1"
+	ber "gopkg.in/asn1-ber.v1"
 )
 
 // LDAP Application Codes
@@ -365,4 +365,39 @@ func getLDAPResultCode(packet *ber.Packet) (code uint8, description string) {
 	}
 
 	return ErrorNetwork, "Invalid packet format"
+}
+
+var hex = "0123456789abcdef"
+
+func mustEscape(c byte) bool {
+	return c > 0x7f || c == '(' || c == ')' || c == '\\' || c == '*' || c == 0
+}
+
+// EscapeFilter escapes from the provided LDAP filter string the special
+// characters in the set `()*\` and those out of the range 0 < c < 0x80,
+// as defined in RFC4515.
+func EscapeFilter(filter string) string {
+	escape := 0
+	for i := 0; i < len(filter); i++ {
+		if mustEscape(filter[i]) {
+			escape++
+		}
+	}
+	if escape == 0 {
+		return filter
+	}
+	buf := make([]byte, len(filter)+escape*2)
+	for i, j := 0, 0; i < len(filter); i++ {
+		c := filter[i]
+		if mustEscape(c) {
+			buf[j+0] = '\\'
+			buf[j+1] = hex[c>>4]
+			buf[j+2] = hex[c&0xf]
+			j += 3
+		} else {
+			buf[j] = c
+			j++
+		}
+	}
+	return string(buf)
 }

--- a/ldap_test.go
+++ b/ldap_test.go
@@ -215,3 +215,12 @@ func TestMultiGoroutineSearch(t *testing.T) {
 	testMultiGoroutineSearch(t, true, true)
 	testMultiGoroutineSearch(t, false, true)
 }
+
+func TestEscapeFilter(t *testing.T) {
+	if got, want := EscapeFilter("a\x00b(c)d*e\\f"), `a\00b\28c\29d\2ae\5cf`; got != want {
+		t.Errorf("Got %s, expected %s", want, got)
+	}
+	if got, want := EscapeFilter("Lučić"), `Lu\c4\8di\c4\87`; got != want {
+		t.Errorf("Got %s, expected %s", want, got)
+	}
+}


### PR DESCRIPTION
In order to do LDAP queries from user given input, an escape function should be provided to mitigate ldap injection

Not taking credit for this code - thanks @niemeyer - https://github.com/go-mup/mup/commit/896d6908e5b8ea1fbb26cc73d9be3f816aabeb11
