### PR TITLE
Do not set conn to nil when closing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -111,7 +111,6 @@ func (l *Conn) Close() {
 			log.Print(err)
 		}
 
-		l.conn = nil
 		l.wgClose.Done()
 	})
 	l.wgClose.Wait()


### PR DESCRIPTION
Doing this is not useful and can make the reader() goroutine crash with a nil pointer dereference in ber.ReadPacket.
This bug was seen in real life and caused a server crash.

To easily reproduce the bug/race condition:

```go
package main

import (
	"crypto/tls"
	"log"

	"runtime"
	"sync"

	"github.com/go-ldap/ldap"
)

const (
	addr = "testserver:636"
	user = "testuser"
	pass = "anything"
)

func routine(i int, wg *sync.WaitGroup) {
	defer wg.Done()
	ll, err := ldap.DialTLS("tcp", addr, &tls.Config{InsecureSkipVerify: true})
	if err != nil {
		log.Printf("connection failed: %s", err)
		return
	}
	defer ll.Close()
	err = ll.Bind(user, pass)
	if err != nil {
		return
	}
}

func main() {
	for n := 0; n < 50; n++ {
		var wg sync.WaitGroup
		const numRoutines = 100
		wg.Add(numRoutines)
		runtime.GOMAXPROCS(100)
		for i := 0; i < numRoutines; i++ {
			go routine(i, &wg)
		}
		wg.Wait()
	}
}
```