### PR TITLE
Guard against panic in reader and processMessages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -321,7 +321,10 @@ func (l *Conn) reader() {
 		}
 		packet, err := ber.ReadPacket(l.conn)
 		if err != nil {
-			l.Debug.Printf("reader error: %s", err.Error())
+			// A read error is expected here if we are closing the connection...
+			if !l.isClosing {
+				l.Debug.Printf("reader error: %s", err.Error())
+			}
 			return
 		}
 		addLDAPDescriptions(packet)

--- a/conn.go
+++ b/conn.go
@@ -246,6 +246,9 @@ func (l *Conn) sendProcessMessage(message *messagePacket) bool {
 
 func (l *Conn) processMessages() {
 	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("ldap: recovered panic in processMessages: %v", err)
+		}
 		for messageID, channel := range l.chanResults {
 			l.Debug.Printf("Closing channel for MessageID %d", messageID)
 			close(channel)
@@ -303,6 +306,9 @@ func (l *Conn) processMessages() {
 func (l *Conn) reader() {
 	cleanstop := false
 	defer func() {
+		if err := recover(); err != nil {
+			log.Printf("ldap: recovered panic in reader: %v", err)
+		}
 		if !cleanstop {
 			l.Close()
 		}


### PR DESCRIPTION
Any panic here can bring down the whole server since these functions are executed into separate goroutines.
Recover and log any panic in those two functions.
    
(Tested by manually injecting random panics into ber.ReadPacket and ber.Packet.Bytes())

Also minor cleanup to not log read errors while closing a connection.