### PR TITLE
Fixed else condition to return when error is trapped

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -63,8 +63,10 @@ func init() {
 	timeout, err := time.ParseDuration(timeoutVar)
 	if err != nil {
 		ldapTimeout = 60 * time.Second
+		return
 	}
 	ldapTimeout = timeout
+	return
 }
 
 // Dial connects to the given address on the given network using net.Dial


### PR DESCRIPTION
This was missed in the previous commit for some reason.  Pull request added to fix the issue where the error (default value assignment) could still get re-assigned an invalid value