### PR TITLE
Return error from StartTLS when LDAP response does not indicate success.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -186,6 +186,10 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 
 		l.isTLS = true
 		l.conn = conn
+	} else {
+		return NewError(
+			uint8(packet.Children[1].Children[0].Value.(int64)),
+			fmt.Errorf("ldap: cannot StartTLS (%s)", packet.Children[1].Children[2].Value.(string)))
 	}
 	go l.reader()
 

--- a/conn.go
+++ b/conn.go
@@ -176,7 +176,7 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 		ber.PrintPacket(packet)
 	}
 
-	if packet.Children[1].Children[0].Value.(int64) == 0 {
+	if packet.Children[1].Children[0].Value.(int64) == LDAPResultSuccess {
 		conn := tls.Client(l.conn, config)
 
 		if err := conn.Handshake(); err != nil {
@@ -187,6 +187,8 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 		l.isTLS = true
 		l.conn = conn
 	} else {
+		// https://tools.ietf.org/html/rfc4511#section-4.1.9
+		// Children[1].Children[2] is the diagnosticMessage which is guaranteed to exist.
 		return NewError(
 			uint8(packet.Children[1].Children[0].Value.(int64)),
 			fmt.Errorf("ldap: cannot StartTLS (%s)", packet.Children[1].Children[2].Value.(string)))


### PR DESCRIPTION
Currently when an LDAP server returns a result other than success for StartTLS, there is no indication of error to the caller of the function. It seems like an error should be propagated to indicate that a secure connection could not be established.
