### PR TITLE
refactored Conn to use a Client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,23 @@
+package ldap
+
+import "crypto/tls"
+
+// Client knows how to interact with an LDAP server
+type Client interface {
+	Start()
+	StartTLS(config *tls.Config) error
+	Close()
+
+	Bind(username, password string) error
+	SimpleBind(simpleBindRequest *SimpleBindRequest) (*SimpleBindResult, error)
+
+	Add(addRequest *AddRequest) error
+	Del(delRequest *DelRequest) error
+	Modify(modifyRequest *ModifyRequest) error
+
+	Compare(dn, attribute, value string) (bool, error)
+	PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*PasswordModifyResult, error)
+
+	Search(searchRequest *SearchRequest) (*SearchResult, error)
+	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
+}

--- a/conn.go
+++ b/conn.go
@@ -54,6 +54,8 @@ type Conn struct {
 	messageMutex        sync.Mutex
 }
 
+var _ Client = &Conn{}
+
 // DefaultTimeout is a package-level variable that sets the timeout value
 // used for the Dial and DialTLS methods.
 //


### PR DESCRIPTION
In order to be able to unit-test code that depends on this package, it is extremely useful to have a mock `ldap.Conn` that can be injected into the code. In order for this to be possible, this package must define an interface that represents `ldap.Conn`. I've added the `ldap.Client` interface to the package. This *is not* a breaking change to the API for this package as the reference to the connection is returned as before. Users of the `Client` *will* experience a change, however I think that the change is minimal - the only public member of the `ldap.Conn` struct is a debugging construct that I wouldn't expect consumers of this API to be using. All of the current public functions on `ldap.Conn` are exposed by `ldap.Client` and can be accessed as before.

/cc @johnweldon @liggitt 