### PR TITLE
added API method to allow for paged or nonpaged searches

### DIFF
--- a/client.go
+++ b/client.go
@@ -20,4 +20,5 @@ type Client interface {
 
 	Search(searchRequest *SearchRequest) (*SearchResult, error)
 	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
+	SearchAllowingPaging(SearchRequest *SearchRequest) (*SearchResult, error)
 }


### PR DESCRIPTION
We've run into some cases where we need paged searches, but optionally. In these cases, we would really enjoy having a single API all we could make that could introspect the `SearchRequest`. If the request contained a paging control, a buffered paged search would be executed; if the request did not contain a paging control, a normal search would be executed. This PR adds this API call as `SearchAllowingPaging`. No changes are made to `Search` or `SearchWithPaging` functionality.

@johnweldon @liggitt PTAL