### PR TITLE
Tolerate existing paging control in SearchWithPaging

### DIFF
--- a/ldap_test.go
+++ b/ldap_test.go
@@ -151,6 +151,32 @@ func TestSearchWithPaging(t *testing.T) {
 	}
 
 	fmt.Printf("TestSearchWithPaging: %s -> num of entries = %d\n", searchRequest.Filter, len(sr.Entries))
+
+	searchRequest = ldap.NewSearchRequest(
+		baseDN,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
+		filter[2],
+		attributes,
+		[]ldap.Control{ldap.NewControlPaging(5)})
+	sr, err = l.SearchWithPaging(searchRequest, 5)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	fmt.Printf("TestSearchWithPaging: %s -> num of entries = %d\n", searchRequest.Filter, len(sr.Entries))
+
+	searchRequest = ldap.NewSearchRequest(
+		baseDN,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
+		filter[2],
+		attributes,
+		[]ldap.Control{ldap.NewControlPaging(500)})
+	sr, err = l.SearchWithPaging(searchRequest, 5)
+	if err == nil {
+		t.Errorf("expected an error when paging size in control in search request doesn't match size given in call, got none")
+		return
+	}
 }
 
 func searchGoroutine(t *testing.T, l *ldap.Conn, results chan *ldap.SearchResult, i int) {

--- a/search.go
+++ b/search.go
@@ -268,13 +268,32 @@ func NewSearchRequest(
 	}
 }
 
+// SearchWithPaging accepts a search request and desired page size in order to execute LDAP queries to fulfill the
+// search request. All paged LDAP query responses will be buffered and the final result will be returned atomically.
+// The following four cases are possible given the arguments:
+//  - given SearchRequest missing a control of type ControlTypePaging: we will add one with the desired paging size
+//  - given SearchRequest contains a control of type ControlTypePaging that isn't actually a ControlPaging: fail without issuing any queries
+//  - given SearchRequest contains a control of type ControlTypePaging with pagingSize equal to the size requested: no change to the search request
+//  - given SearchRequest contains a control of type ControlTypePaging with pagingSize not equal to the size requested: fail without issuing any queries
+// A requested pagingSize of 0 is interpreted as no limit by LDAP servers.
 func (l *Conn) SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error) {
-	if searchRequest.Controls == nil {
-		searchRequest.Controls = make([]Control, 0)
+	var pagingControl *ControlPaging
+
+	control := FindControl(searchRequest.Controls, ControlTypePaging)
+	if control == nil {
+		pagingControl = NewControlPaging(pagingSize)
+		searchRequest.Controls = append(searchRequest.Controls, pagingControl)
+	} else {
+		castControl, ok := control.(*ControlPaging)
+		if !ok {
+			return nil, fmt.Errorf("Expected paging control to be of type *ControlPaging, got %v", control)
+		}
+		if castControl.PagingSize != pagingSize {
+			return nil, fmt.Errorf("Paging size given in search request (%d) conflicts with size given in search call (%d)", castControl.PagingSize, pagingSize)
+		}
+		pagingControl = castControl
 	}
 
-	pagingControl := NewControlPaging(pagingSize)
-	searchRequest.Controls = append(searchRequest.Controls, pagingControl)
 	searchResult := new(SearchResult)
 	for {
 		result, err := l.Search(searchRequest)


### PR DESCRIPTION
With the current implementation of `Search`, our interaction with this library has been as such: 
 - gather knowledge in order to fully qualify an LDAP query
 - create a `SearchRequest`
 - get a `SearchResponse`
 - unpack the response for salient information

The current API for `SearchWithPaging` does not honor this workflow and expects something *other* than a fully-qualified `SearchRequest` to function. This PR adds another API call that allows for a fully qualified search request to be all that is necessary to issue a request to search with client-side page stitching.

@johnweldon @liggitt  PTAL