### PR TITLE
Handle nil packets when getting LDAPResultCode

### DIFF
--- a/error.go
+++ b/error.go
@@ -99,8 +99,13 @@ var LDAPResultCodeMap = map[uint8]string{
 }
 
 func getLDAPResultCode(packet *ber.Packet) (code uint8, description string) {
-	if len(packet.Children) >= 2 {
+	if packet == nil {
+		return ErrorUnexpectedResponse, "Empty packet"
+	} else if len(packet.Children) >= 2 {
 		response := packet.Children[1]
+		if response == nil {
+			return ErrorUnexpectedResponse, "Empty response in packet"
+		}
 		if response.ClassType == ber.ClassApplication && response.TagType == ber.TypeConstructed && len(response.Children) >= 3 {
 			// Children[1].Children[2] is the diagnosticMessage which is guaranteed to exist as seen here: https://tools.ietf.org/html/rfc4511#section-4.1.9
 			return uint8(response.Children[0].Value.(int64)), response.Children[2].Value.(string)

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,29 @@
+package ldap
+
+import (
+	"testing"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+// TestNilPacket tests that nil packets don't cause a panic.
+func TestNilPacket(t *testing.T) {
+	// Test for nil packet
+	code, _ := getLDAPResultCode(nil)
+	if code != ErrorUnexpectedResponse {
+		t.Errorf("Should have an 'ErrorUnexpectedResponse' error in nil packets, got: %v", code)
+	}
+
+	// Test for nil result
+	kids := []*ber.Packet{
+		&ber.Packet{}, // Unused
+		nil,           // Can't be nil
+	}
+	pack := &ber.Packet{Children: kids}
+	code, _ = getLDAPResultCode(pack)
+
+	if code != ErrorUnexpectedResponse {
+		t.Errorf("Should have an 'ErrorUnexpectedResponse' error in nil packets, got: %v", code)
+	}
+
+}


### PR DESCRIPTION
nil packets have been observed when using StartTLS on a connection that
doesn't support it. These previously caused a panic but now will just
result in an unhelpful error.

Mimicking a similar strategy in https://github.com/go-ldap/ldap/blob/07a7330929b9ee80495c88a4439657d89c7dbd87/ldap.go#L89-L93

The nil packets on invalid StartTLS attempts should eventually be
corrected, but this makes the failure much more graceful.

Closes #58 