### PR TITLE
Add Persistent search control + PersistentSearch()

### DIFF
--- a/control_test.go
+++ b/control_test.go
@@ -1,0 +1,58 @@
+package ldap
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+func TestControlPaging(t *testing.T) {
+	runControlTest(t, NewControlPaging(0))
+	runControlTest(t, NewControlPaging(100))
+}
+
+func TestControlManageDsaIT(t *testing.T) {
+	runControlTest(t, NewControlManageDsaIT(true))
+	runControlTest(t, NewControlManageDsaIT(false))
+}
+
+func TestControlString(t *testing.T) {
+	runControlTest(t, NewControlString("x", true, "y"))
+	runControlTest(t, NewControlString("x", true, ""))
+	runControlTest(t, NewControlString("x", false, "y"))
+	runControlTest(t, NewControlString("x", false, ""))
+}
+
+func runControlTest(t *testing.T, originalControl Control) {
+	header := ""
+	if callerpc, _, line, ok := runtime.Caller(1); ok {
+		if caller := runtime.FuncForPC(callerpc); caller != nil {
+			header = fmt.Sprintf("%s:%d: ", caller.Name(), line)
+		}
+	}
+
+	encodedPacket := originalControl.Encode()
+	encodedBytes := encodedPacket.Bytes()
+
+	// Decode directly from the encoded packet (ensures Value is correct)
+	fromPacket := DecodeControl(encodedPacket)
+	if !bytes.Equal(encodedBytes, fromPacket.Encode().Bytes()) {
+		t.Errorf("%sround-trip from encoded packet failed", header)
+	}
+	if reflect.TypeOf(originalControl) != reflect.TypeOf(fromPacket) {
+		t.Errorf("%sgot different type decoding from encoded packet: %T vs %T", header, fromPacket, originalControl)
+	}
+
+	// Decode from the wire bytes (ensures ber-encoding is correct)
+	fromBytes := DecodeControl(ber.DecodePacket(encodedBytes))
+	if !bytes.Equal(encodedBytes, fromBytes.Encode().Bytes()) {
+		t.Errorf("%sround-trip from encoded bytes failed", header)
+	}
+	if reflect.TypeOf(originalControl) != reflect.TypeOf(fromPacket) {
+		t.Errorf("%sgot different type decoding from encoded bytes: %T vs %T", header, fromBytes, originalControl)
+	}
+}

--- a/psearch_test.go
+++ b/psearch_test.go
@@ -1,0 +1,40 @@
+package ldap_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"gopkg.in/ldap.v2"
+)
+
+func ExamplePersistentSearch() {
+	l, err := ldap.DialTLS("tcp", "ldap.example.org:636", &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		panic("DialTLS: " + err.Error())
+	}
+	_, err = l.SimpleBind(ldap.NewSimpleBindRequest("uid=someone,dc=example,dc=org", "MySecret", nil))
+	if err != nil {
+		panic("SimpleBind(): " + err.Error())
+	}
+	req := &ldap.SearchRequest{
+		BaseDN:     "ou=people,dc=example,dc=org",
+		Scope:      ldap.ScopeWholeSubtree,
+		Filter:     "(uid=*)",
+		Attributes: []string{"uid", "cn"},
+	}
+	l.Debug = true
+	err = l.PersistentSearch(req, []string{"any"}, true, true, callBack)
+	if err != nil {
+		panic("PersistentSearch(): " + err.Error())
+	}
+}
+
+func callBack(res *ldap.SearchResult) bool {
+	if len(res.Entries) != 0 {
+		entry := res.Entries[0]
+		fmt.Printf("%s (%s)\n", entry.GetAttributeValue("cn"), entry.GetAttributeValue("uid"))
+	}
+	if len(res.Controls) != 0 {
+		fmt.Printf("CTRL=%s\n", res.Controls[0].String())
+	}
+	return true
+}


### PR DESCRIPTION
This adds the persistent search control from https://www.ietf.org/proceedings/50/I-D/ldapext-psearch-03.txt. The code comes with a PersistentSearch() function to use this control.

minor change: use the LDAP Application Codes (e.g. ApplicationSearchResultEntry) instead of the int in the result parsing.
