### PR TITLE
Fix control round-tripping, parsing

### DIFF
--- a/control.go
+++ b/control.go
@@ -89,7 +89,7 @@ func (c *ControlPaging) Encode() *ber.Packet {
 
 	p2 := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (Paging)")
 	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Search Control Value")
-	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, uint64(c.PagingSize), "Paging Size"))
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.PagingSize), "Paging Size"))
 	cookie := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Cookie")
 	cookie.Value = c.Cookie
 	cookie.Data.Write(c.Cookie)

--- a/control.go
+++ b/control.go
@@ -254,19 +254,54 @@ func FindControl(controls []Control, controlType string) Control {
 
 // DecodeControl returns a control read from the given packet, or nil if no recognized control can be made
 func DecodeControl(packet *ber.Packet) Control {
-	ControlType := packet.Children[0].Value.(string)
-	Criticality := false
+	var (
+		ControlType = ""
+		Criticality = false
+		value       *ber.Packet
+	)
 
-	packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
-	value := packet.Children[1]
-	if len(packet.Children) == 3 {
-		value = packet.Children[2]
+	switch len(packet.Children) {
+	case 0:
+		// at least one child is required for control type
+		return nil
+
+	case 1:
+		// just type, no criticality or value
+		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
+		ControlType = packet.Children[0].Value.(string)
+
+	case 2:
+		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
+		ControlType = packet.Children[0].Value.(string)
+
+		// Children[1] could be criticality or value (both are optional)
+		// duck-type on whether this is a boolean
+		if _, ok := packet.Children[1].Value.(bool); ok {
+			packet.Children[1].Description = "Criticality"
+			Criticality = packet.Children[1].Value.(bool)
+		} else {
+			packet.Children[1].Description = "Control Value"
+			value = packet.Children[1]
+		}
+
+	case 3:
+		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
+		ControlType = packet.Children[0].Value.(string)
+
 		packet.Children[1].Description = "Criticality"
 		Criticality = packet.Children[1].Value.(bool)
+
+		packet.Children[2].Description = "Control Value"
+		value = packet.Children[2]
+
+	default:
+		// more than 3 children is invalid
+		return nil
 	}
 
-	value.Description = "Control Value"
 	switch ControlType {
+	case ControlTypeManageDsaIT:
+		return NewControlManageDsaIT(Criticality)
 	case ControlTypePaging:
 		value.Description += " (Paging)"
 		c := new(ControlPaging)

--- a/control.go
+++ b/control.go
@@ -377,12 +377,15 @@ func DecodeControl(packet *ber.Packet) Control {
 		value.Value = c.Expire
 
 		return c
+	default:
+		c := new(ControlString)
+		c.ControlType = ControlType
+		c.Criticality = Criticality
+		if value != nil {
+			c.ControlValue = value.Value.(string)
+		}
+		return c
 	}
-	c := new(ControlString)
-	c.ControlType = ControlType
-	c.Criticality = Criticality
-	c.ControlValue = value.Value.(string)
-	return c
 }
 
 // NewControlString returns a generic control

--- a/control_test.go
+++ b/control_test.go
@@ -1,0 +1,46 @@
+package ldap
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+func TestControlPaging(t *testing.T) {
+	runControlTest(t, NewControlPaging(0))
+	runControlTest(t, NewControlPaging(100))
+}
+
+func runControlTest(t *testing.T, originalControl Control) {
+	header := ""
+	if callerpc, _, line, ok := runtime.Caller(1); ok {
+		if caller := runtime.FuncForPC(callerpc); caller != nil {
+			header = fmt.Sprintf("%s:%d: ", caller.Name(), line)
+		}
+	}
+
+	encodedPacket := originalControl.Encode()
+	encodedBytes := encodedPacket.Bytes()
+
+	// Decode directly from the encoded packet (ensures Value is correct)
+	fromPacket := DecodeControl(encodedPacket)
+	if !bytes.Equal(encodedBytes, fromPacket.Encode().Bytes()) {
+		t.Errorf("%sround-trip from encoded packet failed", header)
+	}
+	if reflect.TypeOf(originalControl) != reflect.TypeOf(fromPacket) {
+		t.Errorf("%sgot different type decoding from encoded packet: %T vs %T", header, fromPacket, originalControl)
+	}
+
+	// Decode from the wire bytes (ensures ber-encoding is correct)
+	fromBytes := DecodeControl(ber.DecodePacket(encodedBytes))
+	if !bytes.Equal(encodedBytes, fromBytes.Encode().Bytes()) {
+		t.Errorf("%sround-trip from encoded bytes failed", header)
+	}
+	if reflect.TypeOf(originalControl) != reflect.TypeOf(fromPacket) {
+		t.Errorf("%sgot different type decoding from encoded bytes: %T vs %T", header, fromBytes, originalControl)
+	}
+}

--- a/control_test.go
+++ b/control_test.go
@@ -20,6 +20,13 @@ func TestControlManageDsaIT(t *testing.T) {
 	runControlTest(t, NewControlManageDsaIT(false))
 }
 
+func TestControlString(t *testing.T) {
+	runControlTest(t, NewControlString("x", true, "y"))
+	runControlTest(t, NewControlString("x", true, ""))
+	runControlTest(t, NewControlString("x", false, "y"))
+	runControlTest(t, NewControlString("x", false, ""))
+}
+
 func runControlTest(t *testing.T, originalControl Control) {
 	header := ""
 	if callerpc, _, line, ok := runtime.Caller(1); ok {

--- a/control_test.go
+++ b/control_test.go
@@ -15,6 +15,11 @@ func TestControlPaging(t *testing.T) {
 	runControlTest(t, NewControlPaging(100))
 }
 
+func TestControlManageDsaIT(t *testing.T) {
+	runControlTest(t, NewControlManageDsaIT(true))
+	runControlTest(t, NewControlManageDsaIT(false))
+}
+
 func runControlTest(t *testing.T, originalControl Control) {
 	header := ""
 	if callerpc, _, line, ok := runtime.Caller(1); ok {


### PR DESCRIPTION
Fixes #82, fixes #85

* DecodeControl(DecodePacket(bytes)) already worked correctly
* pagingControl.Encode().Data already worked correctly
* DecodeControl(pagingControl.Encode()) failed, since it didn't actually use the bytes in the packet, and just tried to cast the Value field