### PR TITLE
Fix decoding if criticality is missing

### DIFF
--- a/control.go
+++ b/control.go
@@ -257,16 +257,22 @@ func DecodeControl(packet *ber.Packet) Control {
 	ControlType := packet.Children[0].Value.(string)
 	Criticality := false
 
+	var value *ber.Packet
 	packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
-	value := packet.Children[1]
-	if len(packet.Children) == 3 {
-		value = packet.Children[2]
-		packet.Children[1].Description = "Criticality"
-		Criticality = packet.Children[1].Value.(bool)
+	if len(packet.Children) > 1 {
+		value = packet.Children[1]
+		if len(packet.Children) == 3 {
+			value = packet.Children[2]
+			packet.Children[1].Description = "Criticality"
+			Criticality = packet.Children[1].Value.(bool)
+		}
+		value.Description = "Control Value"
 	}
 
-	value.Description = "Control Value"
 	switch ControlType {
+	case ControlTypeManageDsaIT:
+		return NewControlManageDsaIT(Criticality)
+
 	case ControlTypePaging:
 		value.Description += " (Paging)"
 		c := new(ControlPaging)

--- a/control_test.go
+++ b/control_test.go
@@ -1,0 +1,15 @@
+package ldap
+
+import (
+	"testing"
+)
+
+func TestControlManageDsaITEncodeDecode(t *testing.T) {
+	c := NewControlManageDsaIT(true)
+	packet := c.Encode()
+	_ = DecodeControl(packet)
+
+	c = NewControlManageDsaIT(false)
+	packet = c.Encode()
+	_ = DecodeControl(packet)
+}


### PR DESCRIPTION
another one, similar to #82:
*  check length of packet.Children
* explicit decoding of ControlManageDsaIT - it panic'd with a
  Criticality = false (fell through to ControlString, there a type conversion panic)