### PR TITLE
Extend Control interface

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -85,7 +85,11 @@ func (l *Conn) SimpleBind(simpleBindRequest *SimpleBindRequest) (*SimpleBindResu
 
 	if len(packet.Children) == 3 {
 		for _, child := range packet.Children[2].Children {
-			result.Controls = append(result.Controls, DecodeControl(child))
+			ctrl, err := DecodeControl(child)
+			if err != nil {
+				return nil, err
+			}
+			result.Controls = append(result.Controls, ctrl)
 		}
 	}
 

--- a/control.go
+++ b/control.go
@@ -5,33 +5,73 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
-	"strconv"
+	"reflect"
+	"sync"
 
 	"gopkg.in/asn1-ber.v1"
 )
 
-const (
-	// ControlTypePaging - https://www.ietf.org/rfc/rfc2696.txt
-	ControlTypePaging = "1.2.840.113556.1.4.319"
-	// ControlTypeBeheraPasswordPolicy - https://tools.ietf.org/html/draft-behera-ldap-password-policy-10
-	ControlTypeBeheraPasswordPolicy = "1.3.6.1.4.1.42.2.27.8.5.1"
-	// ControlTypeVChuPasswordMustChange - https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
-	ControlTypeVChuPasswordMustChange = "2.16.840.1.113730.3.4.4"
-	// ControlTypeVChuPasswordWarning - https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
-	ControlTypeVChuPasswordWarning = "2.16.840.1.113730.3.4.5"
-	// ControlTypeManageDsaIT - https://tools.ietf.org/html/rfc3296
-	ControlTypeManageDsaIT = "2.16.840.1.113730.3.4.2"
-)
+// controlTypeMap maps controls to text descriptions
+var controlTypeMap = make(map[string]controlType)
+var controlTypeMapLock = sync.Mutex{}
 
-// ControlTypeMap maps controls to text descriptions
-var ControlTypeMap = map[string]string{
-	ControlTypePaging:               "Paging",
-	ControlTypeBeheraPasswordPolicy: "Password Policy - Behera Draft",
-	ControlTypeManageDsaIT:          "Manage DSA IT",
+type controlType struct {
+	Description string
+	Control     Control
 }
 
-// Control defines an interface controls provide to encode and describe themselves
+// RegisterControl adds a Control to the map of known Controls.
+func RegisterControl(oid, description string, ctrl Control) {
+	if ctrl == nil {
+		return
+	}
+	controlTypeMapLock.Lock()
+	defer controlTypeMapLock.Unlock()
+	controlTypeMap[oid] = controlType{
+		Control:     ctrl,
+		Description: description,
+	}
+}
+
+// GetControl returns an empty new initialized Control for the
+// given ControlType (OID). Returns nil if the Control has not
+// been registered with RegisterControl() before.
+func GetControl(oid string) Control {
+	controlTypeMapLock.Lock()
+	ctrl, ok := controlTypeMap[oid]
+	controlTypeMapLock.Unlock()
+	if !ok {
+		return nil
+	}
+	// Indirect returns the value that v points to. [...] If v is
+	// not a pointer, Indirect returns v.
+	refVal := reflect.ValueOf(ctrl.Control)
+	indVal := reflect.Indirect(refVal)
+	if refVal == indVal {
+		// we got something like "type ControlManageDsaIT bool" as Control.
+		// reflect.New returns pointer type -> use indirect
+		return reflect.Indirect(reflect.New(refVal.Type())).Interface().(Control)
+	}
+	// got pointer to something as Control
+	return reflect.New(indVal.Type()).Interface().(Control)
+}
+
+// ControlDescription returns the description for the Control as it was
+// passed to RegisterControl().
+func ControlDescription(oid string) string {
+	controlTypeMapLock.Lock()
+	defer controlTypeMapLock.Unlock()
+	ctrl, ok := controlTypeMap[oid]
+	if !ok {
+		return ""
+	}
+	return ctrl.Description
+}
+
+// Control defines an interface controls provide to encode,
+// decode and describe themselves
 type Control interface {
 	// GetControlType returns the OID
 	GetControlType() string
@@ -39,6 +79,10 @@ type Control interface {
 	Encode() *ber.Packet
 	// String returns a human-readable description
 	String() string
+	// Decode decodes the Control
+	Decode(bool, *ber.Packet) (Control, error)
+	// Describe adds descritptions to the control value
+	Describe(*ber.Packet)
 }
 
 // ControlString implements the Control interface for simple controls
@@ -56,7 +100,7 @@ func (c *ControlString) GetControlType() string {
 // Encode returns the ber packet representation
 func (c *ControlString) Encode() *ber.Packet {
 	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.ControlType, "Control Type ("+ControlTypeMap[c.ControlType]+")"))
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.ControlType, "Control Type ("+ControlDescription(c.ControlType)+")"))
 	if c.Criticality {
 		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
 	}
@@ -66,180 +110,7 @@ func (c *ControlString) Encode() *ber.Packet {
 
 // String returns a human-readable description
 func (c *ControlString) String() string {
-	return fmt.Sprintf("Control Type: %s (%q)  Criticality: %t  Control Value: %s", ControlTypeMap[c.ControlType], c.ControlType, c.Criticality, c.ControlValue)
-}
-
-// ControlPaging implements the paging control described in https://www.ietf.org/rfc/rfc2696.txt
-type ControlPaging struct {
-	// PagingSize indicates the page size
-	PagingSize uint32
-	// Cookie is an opaque value returned by the server to track a paging cursor
-	Cookie []byte
-}
-
-// GetControlType returns the OID
-func (c *ControlPaging) GetControlType() string {
-	return ControlTypePaging
-}
-
-// Encode returns the ber packet representation
-func (c *ControlPaging) Encode() *ber.Packet {
-	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypePaging, "Control Type ("+ControlTypeMap[ControlTypePaging]+")"))
-
-	p2 := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (Paging)")
-	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Search Control Value")
-	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.PagingSize), "Paging Size"))
-	cookie := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Cookie")
-	cookie.Value = c.Cookie
-	cookie.Data.Write(c.Cookie)
-	seq.AppendChild(cookie)
-	p2.AppendChild(seq)
-
-	packet.AppendChild(p2)
-	return packet
-}
-
-// String returns a human-readable description
-func (c *ControlPaging) String() string {
-	return fmt.Sprintf(
-		"Control Type: %s (%q)  Criticality: %t  PagingSize: %d  Cookie: %q",
-		ControlTypeMap[ControlTypePaging],
-		ControlTypePaging,
-		false,
-		c.PagingSize,
-		c.Cookie)
-}
-
-// SetCookie stores the given cookie in the paging control
-func (c *ControlPaging) SetCookie(cookie []byte) {
-	c.Cookie = cookie
-}
-
-// ControlBeheraPasswordPolicy implements the control described in https://tools.ietf.org/html/draft-behera-ldap-password-policy-10
-type ControlBeheraPasswordPolicy struct {
-	// Expire contains the number of seconds before a password will expire
-	Expire int64
-	// Grace indicates the remaining number of times a user will be allowed to authenticate with an expired password
-	Grace int64
-	// Error indicates the error code
-	Error int8
-	// ErrorString is a human readable error
-	ErrorString string
-}
-
-// GetControlType returns the OID
-func (c *ControlBeheraPasswordPolicy) GetControlType() string {
-	return ControlTypeBeheraPasswordPolicy
-}
-
-// Encode returns the ber packet representation
-func (c *ControlBeheraPasswordPolicy) Encode() *ber.Packet {
-	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeBeheraPasswordPolicy, "Control Type ("+ControlTypeMap[ControlTypeBeheraPasswordPolicy]+")"))
-
-	return packet
-}
-
-// String returns a human-readable description
-func (c *ControlBeheraPasswordPolicy) String() string {
-	return fmt.Sprintf(
-		"Control Type: %s (%q)  Criticality: %t  Expire: %d  Grace: %d  Error: %d, ErrorString: %s",
-		ControlTypeMap[ControlTypeBeheraPasswordPolicy],
-		ControlTypeBeheraPasswordPolicy,
-		false,
-		c.Expire,
-		c.Grace,
-		c.Error,
-		c.ErrorString)
-}
-
-// ControlVChuPasswordMustChange implements the control described in https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
-type ControlVChuPasswordMustChange struct {
-	// MustChange indicates if the password is required to be changed
-	MustChange bool
-}
-
-// GetControlType returns the OID
-func (c *ControlVChuPasswordMustChange) GetControlType() string {
-	return ControlTypeVChuPasswordMustChange
-}
-
-// Encode returns the ber packet representation
-func (c *ControlVChuPasswordMustChange) Encode() *ber.Packet {
-	return nil
-}
-
-// String returns a human-readable description
-func (c *ControlVChuPasswordMustChange) String() string {
-	return fmt.Sprintf(
-		"Control Type: %s (%q)  Criticality: %t  MustChange: %v",
-		ControlTypeMap[ControlTypeVChuPasswordMustChange],
-		ControlTypeVChuPasswordMustChange,
-		false,
-		c.MustChange)
-}
-
-// ControlVChuPasswordWarning implements the control described in https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
-type ControlVChuPasswordWarning struct {
-	// Expire indicates the time in seconds until the password expires
-	Expire int64
-}
-
-// GetControlType returns the OID
-func (c *ControlVChuPasswordWarning) GetControlType() string {
-	return ControlTypeVChuPasswordWarning
-}
-
-// Encode returns the ber packet representation
-func (c *ControlVChuPasswordWarning) Encode() *ber.Packet {
-	return nil
-}
-
-// String returns a human-readable description
-func (c *ControlVChuPasswordWarning) String() string {
-	return fmt.Sprintf(
-		"Control Type: %s (%q)  Criticality: %t  Expire: %b",
-		ControlTypeMap[ControlTypeVChuPasswordWarning],
-		ControlTypeVChuPasswordWarning,
-		false,
-		c.Expire)
-}
-
-// ControlManageDsaIT implements the control described in https://tools.ietf.org/html/rfc3296
-type ControlManageDsaIT struct {
-	// Criticality indicates if this control is required
-	Criticality bool
-}
-
-// GetControlType returns the OID
-func (c *ControlManageDsaIT) GetControlType() string {
-	return ControlTypeManageDsaIT
-}
-
-// Encode returns the ber packet representation
-func (c *ControlManageDsaIT) Encode() *ber.Packet {
-	//FIXME
-	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeManageDsaIT, "Control Type ("+ControlTypeMap[ControlTypeManageDsaIT]+")"))
-	if c.Criticality {
-		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
-	}
-	return packet
-}
-
-// String returns a human-readable description
-func (c *ControlManageDsaIT) String() string {
-	return fmt.Sprintf(
-		"Control Type: %s (%q)  Criticality: %t",
-		ControlTypeMap[ControlTypeManageDsaIT],
-		ControlTypeManageDsaIT,
-		c.Criticality)
-}
-
-// NewControlManageDsaIT returns a ControlManageDsaIT control
-func NewControlManageDsaIT(Criticality bool) *ControlManageDsaIT {
-	return &ControlManageDsaIT{Criticality: Criticality}
+	return fmt.Sprintf("Control Type: %s (%q)  Criticality: %t  Control Value: %s", ControlDescription(c.ControlType), c.ControlType, c.Criticality, c.ControlValue)
 }
 
 // FindControl returns the first control of the given type in the list, or nil
@@ -253,7 +124,7 @@ func FindControl(controls []Control, controlType string) Control {
 }
 
 // DecodeControl returns a control read from the given packet, or nil if no recognized control can be made
-func DecodeControl(packet *ber.Packet) Control {
+func DecodeControl(packet *ber.Packet) (Control, error) {
 	var (
 		ControlType = ""
 		Criticality = false
@@ -263,15 +134,15 @@ func DecodeControl(packet *ber.Packet) Control {
 	switch len(packet.Children) {
 	case 0:
 		// at least one child is required for control type
-		return nil
+		return nil, errors.New("at least one child is required for control type")
 
 	case 1:
 		// just type, no criticality or value
-		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
+		packet.Children[0].Description = "Control Type (" + ControlDescription(ControlType) + ")"
 		ControlType = packet.Children[0].Value.(string)
 
 	case 2:
-		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
+		packet.Children[0].Description = "Control Type (" + ControlDescription(ControlType) + ")"
 		ControlType = packet.Children[0].Value.(string)
 
 		// Children[1] could be criticality or value (both are optional)
@@ -285,7 +156,7 @@ func DecodeControl(packet *ber.Packet) Control {
 		}
 
 	case 3:
-		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
+		packet.Children[0].Description = "Control Type (" + ControlDescription(ControlType) + ")"
 		ControlType = packet.Children[0].Value.(string)
 
 		packet.Children[1].Description = "Criticality"
@@ -296,96 +167,38 @@ func DecodeControl(packet *ber.Packet) Control {
 
 	default:
 		// more than 3 children is invalid
-		return nil
+		return nil, errors.New("more than 3 children is invalid")
 	}
 
-	switch ControlType {
-	case ControlTypeManageDsaIT:
-		return NewControlManageDsaIT(Criticality)
-	case ControlTypePaging:
-		value.Description += " (Paging)"
-		c := new(ControlPaging)
-		if value.Value != nil {
-			valueChildren := ber.DecodePacket(value.Data.Bytes())
-			value.Data.Truncate(0)
-			value.Value = nil
-			value.AppendChild(valueChildren)
+	ctrl := GetControl(ControlType)
+	var err error
+	if ctrl != nil {
+		if ctrl, err = ctrl.Decode(Criticality, value); err != nil {
+			return nil, err
 		}
-		value = value.Children[0]
-		value.Description = "Search Control Value"
-		value.Children[0].Description = "Paging Size"
-		value.Children[1].Description = "Cookie"
-		c.PagingSize = uint32(value.Children[0].Value.(int64))
-		c.Cookie = value.Children[1].Data.Bytes()
-		value.Children[1].Value = c.Cookie
-		return c
-	case ControlTypeBeheraPasswordPolicy:
-		value.Description += " (Password Policy - Behera)"
-		c := NewControlBeheraPasswordPolicy()
-		if value.Value != nil {
-			valueChildren := ber.DecodePacket(value.Data.Bytes())
-			value.Data.Truncate(0)
-			value.Value = nil
-			value.AppendChild(valueChildren)
-		}
-
-		sequence := value.Children[0]
-
-		for _, child := range sequence.Children {
-			if child.Tag == 0 {
-				//Warning
-				child := child.Children[0]
-				packet := ber.DecodePacket(child.Data.Bytes())
-				val, ok := packet.Value.(int64)
-				if ok {
-					if child.Tag == 0 {
-						//timeBeforeExpiration
-						c.Expire = val
-						child.Value = c.Expire
-					} else if child.Tag == 1 {
-						//graceAuthNsRemaining
-						c.Grace = val
-						child.Value = c.Grace
-					}
-				}
-			} else if child.Tag == 1 {
-				// Error
-				packet := ber.DecodePacket(child.Data.Bytes())
-				val, ok := packet.Value.(int8)
-				if !ok {
-					// what to do?
-					val = -1
-				}
-				c.Error = val
-				child.Value = c.Error
-				c.ErrorString = BeheraPasswordPolicyErrorMap[c.Error]
-			}
-		}
-		return c
-	case ControlTypeVChuPasswordMustChange:
-		c := &ControlVChuPasswordMustChange{MustChange: true}
-		return c
-	case ControlTypeVChuPasswordWarning:
-		c := &ControlVChuPasswordWarning{Expire: -1}
-		expireStr := ber.DecodeString(value.Data.Bytes())
-
-		expire, err := strconv.ParseInt(expireStr, 10, 64)
-		if err != nil {
-			return nil
-		}
-		c.Expire = expire
-		value.Value = c.Expire
-
-		return c
-	default:
-		c := new(ControlString)
-		c.ControlType = ControlType
-		c.Criticality = Criticality
-		if value != nil {
-			c.ControlValue = value.Value.(string)
-		}
-		return c
+		return ctrl, nil
 	}
+	cs := new(ControlString)
+	cs.ControlType = ControlType
+	if ctrl, err = cs.Decode(Criticality, value); err != nil { // should not happen
+		return nil, err
+	}
+	return ctrl, nil
+}
+
+// Describe adds description to the control value. For the ControlString
+// it's a no-op.
+func (c *ControlString) Describe(_ *ber.Packet) {
+	return
+}
+
+// Decode decodes the control value.
+func (c *ControlString) Decode(Criticality bool, value *ber.Packet) (Control, error) {
+	c.Criticality = Criticality
+	if value != nil {
+		c.ControlValue = value.Value.(string)
+	}
+	return c, nil
 }
 
 // NewControlString returns a generic control
@@ -394,20 +207,6 @@ func NewControlString(controlType string, criticality bool, controlValue string)
 		ControlType:  controlType,
 		Criticality:  criticality,
 		ControlValue: controlValue,
-	}
-}
-
-// NewControlPaging returns a paging control
-func NewControlPaging(pagingSize uint32) *ControlPaging {
-	return &ControlPaging{PagingSize: pagingSize}
-}
-
-// NewControlBeheraPasswordPolicy returns a ControlBeheraPasswordPolicy
-func NewControlBeheraPasswordPolicy() *ControlBeheraPasswordPolicy {
-	return &ControlBeheraPasswordPolicy{
-		Expire: -1,
-		Grace:  -1,
-		Error:  -1,
 	}
 }
 

--- a/control_behera_passwordpolicy.go
+++ b/control_behera_passwordpolicy.go
@@ -1,0 +1,150 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ldap
+
+import (
+	"fmt"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+// ControlTypeBeheraPasswordPolicy - https://tools.ietf.org/html/draft-behera-ldap-password-policy-10
+const ControlTypeBeheraPasswordPolicy = "1.3.6.1.4.1.42.2.27.8.5.1"
+
+// ControlBeheraPasswordPolicy implements the control described in https://tools.ietf.org/html/draft-behera-ldap-password-policy-10
+type ControlBeheraPasswordPolicy struct {
+	// Expire contains the number of seconds before a password will expire
+	Expire int64
+	// Grace indicates the remaining number of times a user will be allowed to authenticate with an expired password
+	Grace int64
+	// Error indicates the error code
+	Error int8
+	// ErrorString is a human readable error
+	ErrorString string
+}
+
+func init() {
+	RegisterControl(ControlTypeBeheraPasswordPolicy, "Password Policy - Behera Draft", &ControlBeheraPasswordPolicy{})
+}
+
+// GetControlType returns the OID
+func (c *ControlBeheraPasswordPolicy) GetControlType() string {
+	return ControlTypeBeheraPasswordPolicy
+}
+
+// Encode returns the ber packet representation
+func (c *ControlBeheraPasswordPolicy) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeBeheraPasswordPolicy, "Control Type ("+ControlDescription(ControlTypeBeheraPasswordPolicy)+")"))
+
+	return packet
+}
+
+// String returns a human-readable description
+func (c *ControlBeheraPasswordPolicy) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)  Criticality: %t  Expire: %d  Grace: %d  Error: %d, ErrorString: %s",
+		ControlDescription(ControlTypeBeheraPasswordPolicy),
+		ControlTypeBeheraPasswordPolicy,
+		false,
+		c.Expire,
+		c.Grace,
+		c.Error,
+		c.ErrorString)
+}
+
+// Describe adds descritptions to the control value
+func (c *ControlBeheraPasswordPolicy) Describe(value *ber.Packet) {
+	value.Description += " (Password Policy - Behera Draft)"
+	if value.Value != nil {
+		valueChildren := ber.DecodePacket(value.Data.Bytes())
+		value.Data.Truncate(0)
+		value.Value = nil
+		value.AppendChild(valueChildren)
+	}
+	sequence := value.Children[0]
+	for _, child := range sequence.Children {
+		if child.Tag == 0 {
+			//Warning
+			child := child.Children[0]
+			packet := ber.DecodePacket(child.Data.Bytes())
+			val, ok := packet.Value.(int64)
+			if ok {
+				if child.Tag == 0 {
+					//timeBeforeExpiration
+					value.Description += " (TimeBeforeExpiration)"
+					child.Value = val
+				} else if child.Tag == 1 {
+					//graceAuthNsRemaining
+					value.Description += " (GraceAuthNsRemaining)"
+					child.Value = val
+				}
+			}
+		} else if child.Tag == 1 {
+			// Error
+			packet := ber.DecodePacket(child.Data.Bytes())
+			val, ok := packet.Value.(int8)
+			if !ok {
+				val = -1
+			}
+			child.Description = "Error"
+			child.Value = val
+		}
+	}
+}
+
+// Decode decodes a ControlBeheraPasswordPolicy control value
+func (c *ControlBeheraPasswordPolicy) Decode(criticality bool, value *ber.Packet) (Control, error) {
+	value.Description += " (Password Policy - Behera)"
+	if value.Value != nil {
+		valueChildren := ber.DecodePacket(value.Data.Bytes())
+		value.Data.Truncate(0)
+		value.Value = nil
+		value.AppendChild(valueChildren)
+	}
+
+	sequence := value.Children[0]
+
+	for _, child := range sequence.Children {
+		if child.Tag == 0 {
+			//Warning
+			child := child.Children[0]
+			packet := ber.DecodePacket(child.Data.Bytes())
+			val, ok := packet.Value.(int64)
+			if ok {
+				if child.Tag == 0 {
+					//timeBeforeExpiration
+					c.Expire = val
+					child.Value = c.Expire
+				} else if child.Tag == 1 {
+					//graceAuthNsRemaining
+					c.Grace = val
+					child.Value = c.Grace
+				}
+			}
+		} else if child.Tag == 1 {
+			// Error
+			packet := ber.DecodePacket(child.Data.Bytes())
+			val, ok := packet.Value.(int8)
+			if !ok {
+				// what to do?
+				val = -1
+			}
+			c.Error = val
+			child.Value = c.Error
+			c.ErrorString = BeheraPasswordPolicyErrorMap[c.Error]
+		}
+	}
+	return c, nil
+}
+
+// NewControlBeheraPasswordPolicy returns a ControlBeheraPasswordPolicy
+func NewControlBeheraPasswordPolicy() *ControlBeheraPasswordPolicy {
+	return &ControlBeheraPasswordPolicy{
+		Expire: -1,
+		Grace:  -1,
+		Error:  -1,
+	}
+}

--- a/control_managedsait.go
+++ b/control_managedsait.go
@@ -50,7 +50,7 @@ func (c ControlManageDsaIT) String() string {
 		"Control Type: %s (%q)  Criticality: %t",
 		ControlDescription(ControlTypeManageDsaIT),
 		ControlTypeManageDsaIT,
-		c)
+		bool(c))
 }
 
 // NewControlManageDsaIT returns a ControlManageDsaIT control

--- a/control_managedsait.go
+++ b/control_managedsait.go
@@ -1,0 +1,68 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ldap
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+// ControlTypeManageDsaIT - https://tools.ietf.org/html/rfc3296
+const ControlTypeManageDsaIT = "2.16.840.1.113730.3.4.2"
+
+// ControlManageDsaIT implements the control described in https://tools.ietf.org/html/rfc3296
+// The boolean value indicates if this control is required
+type ControlManageDsaIT bool
+
+func init() {
+	RegisterControl(ControlTypeManageDsaIT, "Manage DSA IT", ControlManageDsaIT(false))
+}
+
+// GetControlType returns the OID
+func (c ControlManageDsaIT) GetControlType() string {
+	return ControlTypeManageDsaIT
+}
+
+// Describe adds descriptions to the value
+func (c ControlManageDsaIT) Describe(value *ber.Packet) {
+	// no control value, just return
+	return
+}
+
+// Encode returns the ber packet representation
+func (c ControlManageDsaIT) Encode() *ber.Packet {
+	//FIXME
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeManageDsaIT, "Control Type ("+ControlDescription(ControlTypeManageDsaIT)+")"))
+	if c {
+		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, bool(c), "Criticality"))
+	}
+	return packet
+}
+
+// String returns a human-readable description
+func (c ControlManageDsaIT) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)  Criticality: %t",
+		ControlDescription(ControlTypeManageDsaIT),
+		ControlTypeManageDsaIT,
+		c)
+}
+
+// NewControlManageDsaIT returns a ControlManageDsaIT control
+func NewControlManageDsaIT(Criticality bool) ControlManageDsaIT {
+	return ControlManageDsaIT(Criticality)
+}
+
+// Decode decodes a ControlManageDsaIT control value
+func (c ControlManageDsaIT) Decode(criticality bool, value *ber.Packet) (Control, error) {
+	c = ControlManageDsaIT(criticality)
+	if value != nil {
+		return nil, errors.New("unexpected value != nil")
+	}
+	return c, nil
+}

--- a/control_paging.go
+++ b/control_paging.go
@@ -1,0 +1,104 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ldap
+
+import (
+	"fmt"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+// ControlTypePaging - https://www.ietf.org/rfc/rfc2696.txt
+const ControlTypePaging = "1.2.840.113556.1.4.319"
+
+// ControlPaging implements the paging control described in https://www.ietf.org/rfc/rfc2696.txt
+type ControlPaging struct {
+	// PagingSize indicates the page size
+	PagingSize uint32
+	// Cookie is an opaque value returned by the server to track a paging cursor
+	Cookie []byte
+}
+
+// GetControlType returns the OID
+func (c *ControlPaging) GetControlType() string {
+	return ControlTypePaging
+}
+
+func init() {
+	RegisterControl(ControlTypePaging, "Paging", &ControlPaging{})
+}
+
+// Encode returns the ber packet representation
+func (c *ControlPaging) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypePaging, "Control Type ("+ControlDescription(ControlTypePaging)+")"))
+
+	p2 := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (Paging)")
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Search Control Value")
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.PagingSize), "Paging Size"))
+	cookie := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Cookie")
+	cookie.Value = c.Cookie
+	cookie.Data.Write(c.Cookie)
+	seq.AppendChild(cookie)
+	p2.AppendChild(seq)
+
+	packet.AppendChild(p2)
+	return packet
+}
+
+// Describe adds descritptions to the control value
+func (c *ControlPaging) Describe(value *ber.Packet) {
+	value.Description += " (Paging)"
+	if value.Value != nil {
+		valueChildren := ber.DecodePacket(value.Data.Bytes())
+		value.Data.Truncate(0)
+		value.Value = nil
+		valueChildren.Children[1].Value = valueChildren.Children[1].Data.Bytes()
+		value.AppendChild(valueChildren)
+	}
+	value.Children[0].Description = "Real Search Control Value"
+	value.Children[0].Children[0].Description = "Paging Size"
+	value.Children[0].Children[1].Description = "Cookie"
+}
+
+// String returns a human-readable description
+func (c *ControlPaging) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)  Criticality: %t  PagingSize: %d  Cookie: %q",
+		ControlDescription(ControlTypePaging),
+		ControlTypePaging,
+		false,
+		c.PagingSize,
+		c.Cookie)
+}
+
+// SetCookie stores the given cookie in the paging control
+func (c *ControlPaging) SetCookie(cookie []byte) {
+	c.Cookie = cookie
+}
+
+// Decode decodes a ControlPaging control value
+func (c *ControlPaging) Decode(criticality bool, value *ber.Packet) (Control, error) {
+	value.Description += " (Paging)"
+	if value.Value != nil {
+		valueChildren := ber.DecodePacket(value.Data.Bytes())
+		value.Data.Truncate(0)
+		value.Value = nil
+		value.AppendChild(valueChildren)
+	}
+	value = value.Children[0]
+	value.Description = "Search Control Value"
+	value.Children[0].Description = "Paging Size"
+	value.Children[1].Description = "Cookie"
+	c.PagingSize = uint32(value.Children[0].Value.(int64))
+	c.Cookie = value.Children[1].Data.Bytes()
+	value.Children[1].Value = c.Cookie
+	return c, nil
+}
+
+// NewControlPaging returns a paging control
+func NewControlPaging(pagingSize uint32) *ControlPaging {
+	return &ControlPaging{PagingSize: pagingSize}
+}

--- a/control_test.go
+++ b/control_test.go
@@ -39,7 +39,10 @@ func runControlTest(t *testing.T, originalControl Control) {
 	encodedBytes := encodedPacket.Bytes()
 
 	// Decode directly from the encoded packet (ensures Value is correct)
-	fromPacket := DecodeControl(encodedPacket)
+	fromPacket, err := DecodeControl(encodedPacket)
+	if err != nil {
+		t.Errorf("DecodeControl returned error: %s", err)
+	}
 	if !bytes.Equal(encodedBytes, fromPacket.Encode().Bytes()) {
 		t.Errorf("%sround-trip from encoded packet failed", header)
 	}
@@ -48,7 +51,10 @@ func runControlTest(t *testing.T, originalControl Control) {
 	}
 
 	// Decode from the wire bytes (ensures ber-encoding is correct)
-	fromBytes := DecodeControl(ber.DecodePacket(encodedBytes))
+	fromBytes, err := DecodeControl(ber.DecodePacket(encodedBytes))
+	if err != nil {
+		t.Errorf("DecodeControl returned error: %s", err)
+	}
 	if !bytes.Equal(encodedBytes, fromBytes.Encode().Bytes()) {
 		t.Errorf("%sround-trip from encoded bytes failed", header)
 	}

--- a/control_vchu_password.go
+++ b/control_vchu_password.go
@@ -1,0 +1,106 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ldap
+
+import (
+	"fmt"
+	"strconv"
+
+	"gopkg.in/asn1-ber.v1"
+)
+
+// ControlTypeVChuPasswordMustChange - https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
+const ControlTypeVChuPasswordMustChange = "2.16.840.1.113730.3.4.4"
+
+// ControlTypeVChuPasswordWarning - https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
+const ControlTypeVChuPasswordWarning = "2.16.840.1.113730.3.4.5"
+
+func init() {
+	RegisterControl(ControlTypeVChuPasswordMustChange, "VChu Password Must Change", &ControlVChuPasswordMustChange{})
+	RegisterControl(ControlTypeVChuPasswordWarning, "VChu Password Warning", &ControlVChuPasswordWarning{})
+}
+
+// ControlVChuPasswordMustChange implements the control described in https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
+type ControlVChuPasswordMustChange struct {
+	// MustChange indicates if the password is required to be changed
+	MustChange bool
+}
+
+// GetControlType returns the OID
+func (c *ControlVChuPasswordMustChange) GetControlType() string {
+	return ControlTypeVChuPasswordMustChange
+}
+
+// Describe adds descritptions to the control value
+func (c *ControlVChuPasswordMustChange) Describe(value *ber.Packet) {
+	// FIXME
+	return
+}
+
+// Encode returns the ber packet representation
+func (c *ControlVChuPasswordMustChange) Encode() *ber.Packet {
+	return nil
+}
+
+// String returns a human-readable description
+func (c *ControlVChuPasswordMustChange) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)  Criticality: %t  MustChange: %v",
+		ControlDescription(ControlTypeVChuPasswordMustChange),
+		ControlTypeVChuPasswordMustChange,
+		false,
+		c.MustChange)
+}
+
+// ControlVChuPasswordWarning implements the control described in https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy-00
+type ControlVChuPasswordWarning struct {
+	// Expire indicates the time in seconds until the password expires
+	Expire int64
+}
+
+// GetControlType returns the OID
+func (c *ControlVChuPasswordWarning) GetControlType() string {
+	return ControlTypeVChuPasswordWarning
+}
+
+// Describe adds descritptions to the control value
+func (c *ControlVChuPasswordWarning) Describe(value *ber.Packet) {
+	// FIXME
+	return
+}
+
+// Encode returns the ber packet representation
+func (c *ControlVChuPasswordWarning) Encode() *ber.Packet {
+	return nil
+}
+
+// String returns a human-readable description
+func (c *ControlVChuPasswordWarning) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)  Criticality: %t  Expire: %b",
+		ControlDescription(ControlTypeVChuPasswordWarning),
+		ControlTypeVChuPasswordWarning,
+		false,
+		c.Expire)
+}
+
+// Decode decodes a ControlVChuPasswordMustChange control value
+func (c *ControlVChuPasswordMustChange) Decode(criticality bool, value *ber.Packet) (Control, error) {
+	return c, nil // FIXME
+}
+
+// Decode decodes a ControlVChuPasswordWarning control value
+func (c *ControlVChuPasswordWarning) Decode(criticality bool, value *ber.Packet) (Control, error) {
+	c.Expire = -1
+	expireStr := ber.DecodeString(value.Data.Bytes())
+
+	expire, err := strconv.ParseInt(expireStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	c.Expire = expire
+	value.Value = c.Expire
+	return c, nil
+}

--- a/ldap.go
+++ b/ldap.go
@@ -164,11 +164,11 @@ func addControlDescriptions(packet *ber.Packet) {
 		case 1:
 			// just type, no criticality or value
 			controlType = child.Children[0].Value.(string)
-			child.Children[0].Description = "Control Type (" + ControlTypeMap[controlType] + ")"
+			child.Children[0].Description = "Control Type (" + ControlDescription(controlType) + ")"
 
 		case 2:
 			controlType = child.Children[0].Value.(string)
-			child.Children[0].Description = "Control Type (" + ControlTypeMap[controlType] + ")"
+			child.Children[0].Description = "Control Type (" + ControlDescription(controlType) + ")"
 			// Children[1] could be criticality or value (both are optional)
 			// duck-type on whether this is a boolean
 			if _, ok := child.Children[1].Value.(bool); ok {
@@ -181,7 +181,7 @@ func addControlDescriptions(packet *ber.Packet) {
 		case 3:
 			// criticality and value present
 			controlType = child.Children[0].Value.(string)
-			child.Children[0].Description = "Control Type (" + ControlTypeMap[controlType] + ")"
+			child.Children[0].Description = "Control Type (" + ControlDescription(controlType) + ")"
 			child.Children[1].Description = "Criticality"
 			child.Children[2].Description = "Control Value"
 			value = child.Children[2]

--- a/search.go
+++ b/search.go
@@ -437,7 +437,11 @@ func (l *Conn) Search(searchRequest *SearchRequest) (*SearchResult, error) {
 			}
 			if len(packet.Children) == 3 {
 				for _, child := range packet.Children[2].Children {
-					result.Controls = append(result.Controls, DecodeControl(child))
+					ctrl, err := DecodeControl(child)
+					if err != nil {
+						return nil, err
+					}
+					result.Controls = append(result.Controls, ctrl)
 				}
 			}
 			foundSearchResultDone = true


### PR DESCRIPTION
With this commit it is easier to add new controls, even controls
not defined in the gopkg.in/ldap.vX package. The new Control just
needs to implement the interface, no knowledge of the control
has to be in the gopkg.in/ldap.vX package.

Note: current state is that both VChu Password controls do not
know how to Encode() or Describe() themself, this should be done
in a separate commit.

Any Control needs to call RegisterControl(oid, description, Control)
to make it self known to the package like the Manage DSA IT control:

``` go
func init() {
   RegisterControl(ControlTypeManageDsaIT, "Manage DSA IT", ControlManageDsaIT(false))
}
```

Changes:
- extend Control interface{}:
  *\* add `Decode(bool, *ber.Packet) (Control, error)` - this
  decodes the Control. To support non pointer controls, we
  need to return the control...
  *\* add `Describe(*ber.Packet)` to add descritptions to the control value
  *\* add missing functions to the existing Controls
  *\* convert ControlManageDsaIT to `type ControlManageDsaIT bool` to show
  it's working
- split all existing Controls (except for ControlString)
  into own file
- DecodeControl():
  *\* returns Control and error (API change)
  *\* just extracts OID, Criticality and the control value,
  calls GetControl(OID) and let the newly initialized Control
  Decode() the value and set Criticality
- utilities:
  *\* add `RegisterControl(oid, description string, ctrl Control)`
  to add a Control to the known controls, call RegisterControl()
  for each existing Control via the init() function
  *\* add `GetControl(oid) Control` to get a newly initialized
  Control for the OID oid
  *\* add `ControlDescription(oid) string` to get the description
  for the Control

Maybe change:
- Return error when passed Control is nil in RegisterControl?
- rename ControlDescription to GetControlDescription?
