### PR TITLE
Ignore unescaped leading/trailing spaces in RDN type/value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 env:
     global:
-        - VET_VERSIONS="1.5 1.6 1.7 tip"
-        - LINT_VERSIONS="1.5 1.6 1.7 tip"
+        - VET_VERSIONS="1.6 1.7 tip"
+        - LINT_VERSIONS="1.6 1.7 tip"
 go:
     - 1.2
     - 1.3

--- a/dn_test.go
+++ b/dn_test.go
@@ -31,6 +31,22 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
 		"CN=Lu\\C4\\8Di\\C4\\87": ldap.DN{[]*ldap.RelativeDN{
 			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"CN", "Lučić"}}}}},
+		"  CN  =  Lu\\C4\\8Di\\C4\\87  ": ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"CN", "Lučić"}}}}},
+		`   A   =   1   ,   B   =   2   `: ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"A", "1"}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"B", "2"}}}}},
+		`   A   =   1   +   B   =   2   `: ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{
+				&ldap.AttributeTypeAndValue{"A", "1"},
+				&ldap.AttributeTypeAndValue{"B", "2"}}}}},
+		`   \ \ A\ \    =   \ \ 1\ \    ,   \ \ B\ \    =   \ \ 2\ \    `: ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"  A  ", "  1  "}}},
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"  B  ", "  2  "}}}}},
+		`   \ \ A\ \    =   \ \ 1\ \    +   \ \ B\ \    =   \ \ 2\ \    `: ldap.DN{[]*ldap.RelativeDN{
+			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{
+				&ldap.AttributeTypeAndValue{"  A  ", "  1  "},
+				&ldap.AttributeTypeAndValue{"  B  ", "  2  "}}}}},
 	}
 
 	for test, answer := range testcases {
@@ -41,6 +57,13 @@ func TestSuccessfulDNParsing(t *testing.T) {
 		}
 		if !reflect.DeepEqual(dn, &answer) {
 			t.Errorf("Parsed DN %s is not equal to the expected structure", test)
+			t.Logf("Expected:")
+			for _, rdn := range answer.RDNs {
+				for _, attribs := range rdn.Attributes {
+					t.Logf("#%v\n", attribs)
+				}
+			}
+			t.Logf("Actual:")
 			for _, rdn := range dn.RDNs {
 				for _, attribs := range rdn.Attributes {
 					t.Logf("#%v\n", attribs)


### PR DESCRIPTION
RFC2253 explicitly says to ignore unescaped leading and trailing space characters in RDN type/values

RFC4514 (which obsoletes RFC2253) does not indicate leading/trailing space characters are to be ignored, but does say they are to be escaped:
```
3.  Parsing a String Back to a Distinguished Name

   The string representation of Distinguished Names is restricted to
   UTF-8 [RFC3629] encoded Unicode [Unicode] characters.  The structure
   of this string representation is specified using the following
   Augmented BNF [RFC4234] grammar:

      distinguishedName = [ relativeDistinguishedName
          *( COMMA relativeDistinguishedName ) ]
      relativeDistinguishedName = attributeTypeAndValue
          *( PLUS attributeTypeAndValue )
      attributeTypeAndValue = attributeType EQUALS attributeValue
      attributeType = descr / numericoid
      attributeValue = string / hexstring

      ; The following characters are to be escaped when they appear
      ; in the value to be encoded: ESC, one of <escaped>, leading
      ; SHARP or SPACE, trailing SPACE, and NULL.
      string =   [ ( leadchar / pair ) [ *( stringchar / pair )
         ( trailchar / pair ) ] ]

      leadchar = LUTF1 / UTFMB
      LUTF1 = %x01-1F / %x21 / %x24-2A / %x2D-3A /
         %x3D / %x3F-5B / %x5D-7F

      trailchar  = TUTF1 / UTFMB
      TUTF1 = %x01-1F / %x21 / %x23-2A / %x2D-3A /
```

given that, if we see leading or trailing unescaped spaces, I think ignoring them is the most reasonable thing to do