### PR TITLE
Fix race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 .PHONY: default install build test quicktest fmt vet lint 
 
+GO_VERSION := $(shell go version | cut -d' ' -f3 | cut -d. -f2)
+
+# Only use the `-race` flag on newer versions of Go
+IS_OLD_GO := $(shell test $(GO_VERSION) -le 2 && echo true)
+ifeq ($(IS_OLD_GO),true)
+	RACE_FLAG :=
+else
+	RACE_FLAG := -race
+endif
+
 default: fmt vet lint build quicktest
 
 install:
@@ -9,7 +19,7 @@ build:
 	go build -v ./...
 
 test:
-	go test -v -cover ./...
+	go test -v $(RACE_FLAG) -cover ./...
 
 quicktest:
 	go test ./...

--- a/atomic_value.go
+++ b/atomic_value.go
@@ -1,0 +1,13 @@
+// +build go1.4
+
+package ldap
+
+import (
+	"sync/atomic"
+)
+
+// For compilers that support it, we just use the underlying sync/atomic.Value
+// type.
+type atomicValue struct {
+	atomic.Value
+}

--- a/atomic_value_go13.go
+++ b/atomic_value_go13.go
@@ -1,0 +1,28 @@
+// +build !go1.4
+
+package ldap
+
+import (
+	"sync"
+)
+
+// This is a helper type that emulates the use of the "sync/atomic.Value"
+// struct that's available in Go 1.4 and up.
+type atomicValue struct {
+	value interface{}
+	lock  sync.RWMutex
+}
+
+func (av *atomicValue) Store(val interface{}) {
+	av.lock.Lock()
+	av.value = val
+	av.lock.Unlock()
+}
+
+func (av *atomicValue) Load() interface{} {
+	av.lock.RLock()
+	ret := av.value
+	av.lock.RUnlock()
+
+	return ret
+}


### PR DESCRIPTION
This should fix some various data races, mostly around the `isClosing` / `closeErr` fields in the `Conn` struct.  I've taken a similar route as #74, but with full support for older versions of Go that don't support the `sync/atomic.Value` struct.