### PR TITLE
escape parenthesis in filter value input

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -173,6 +173,16 @@ var testFilters = []compileTest{
 		expectedType:   ldap.FilterExtensibleMatch,
 	},
 	compileTest{
+		filterStr:      `(&(objectclass=inetorgperson)(memberOf:1.2.840.113556.1.4.1941:=CN=User1 (CA),OU=blah,DC=mydomain,DC=net))`,
+		expectedFilter: `(&(objectclass=inetorgperson)(memberOf:1.2.840.113556.1.4.1941:=CN=User1 \28CA\29,OU=blah,DC=mydomain,DC=net))`,
+		expectedType:   0,
+	},
+	compileTest{
+		filterStr:      `(memberOf:1.2.840.113556.1.4.1941:=CN=User1 (CA),OU=blah,DC=mydomain,DC=net)`,
+		expectedFilter: `(memberOf:1.2.840.113556.1.4.1941:=CN=User1 \28CA\29,OU=blah,DC=mydomain,DC=net)`,
+		expectedType:   ldap.FilterExtensibleMatch,
+	},
+	compileTest{
 		filterStr:      `(memberOf:1.2.840.113556.1.4.1941:=CN=User1,OU=blah,DC=mydomain,DC=net)`,
 		expectedFilter: `(memberOf:1.2.840.113556.1.4.1941:=CN=User1,OU=blah,DC=mydomain,DC=net)`,
 		expectedType:   ldap.FilterExtensibleMatch,


### PR DESCRIPTION
Parentheses must be escaped in search filter assertion values. Only issue I see is that LDAP allows the DN to have something random like `CN= Office ((((,DC=company,DC=com` so there would be an issue there. Let me know your thoughts.