### PR TITLE
Fix typo in error.go file

### DIFF
--- a/error.go
+++ b/error.go
@@ -98,7 +98,7 @@ var LDAPResultCodeMap = map[uint8]string{
 	LDAPResultAffectsMultipleDSAs:          "Affects Multiple DSAs",
 	LDAPResultOther:                        "Other",
 
-	ErrorNetwork:            "Newwork Error",
+	ErrorNetwork:            "Network Error",
 	ErrorFilterCompile:      "Filter Compile Error",
 	ErrorFilterDecompile:    "Filter Decompile Error",
 	ErrorDebugging:          "Debugging Error",


### PR DESCRIPTION
Hi,

This PR only fixes a small typo to the word “Network” in error.go.

Kind regards,
Vincent