### PR TITLE
Cosmetics: Fix example typo

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -193,7 +193,7 @@ func Example_userAuthentication() {
 	searchRequest := ldap.NewSearchRequest(
 		"dc=example,dc=com",
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf("(&(objectClass=organizationalPerson)&(uid=%s))", username),
+		fmt.Sprintf("(&(objectClass=organizationalPerson)(uid=%s))", username),
 		[]string{"dn"},
 		nil,
 	)


### PR DESCRIPTION
Hi,

While playing the userAuthentication example as-is, I end up with the following error because of a typo:
```
2017/03/04 17:51:08 LDAP Result Code 201 "": ldap: finished compiling filter with extra at end: (uid=my.uid))
```

This PR just removes the extra `&`  in the search filter. (Tested against bind9).

Thanks
Joseph
