### PR TITLE
fix compare with active directory

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -37,7 +37,7 @@ func (l *Conn) Compare(dn, attribute, value string) (bool, error) {
 
 	ava := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "AttributeValueAssertion")
 	ava.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, attribute, "AttributeDesc"))
-	ava.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagOctetString, value, "AssertionValue"))
+	ava.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, value, "AssertionValue"))
 	request.AppendChild(ava)
 	packet.AppendChild(request)
 


### PR DESCRIPTION
doing a simple
`l.Compare(<group dn>, "member", <user dn>)`
against an active directory server i'm getting the folling error
00000057: LdapErr: DSID-0C0C1033, comment: Error decoding ldap message, data 0, v2580

This change make my compare request exactly the same as the one produced by php
(I haven't tried to understand the code to see if it break more complicated use case)

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>