### PR TITLE
Remove stale references to BSD license

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package ldap
 
 import (

--- a/compare.go
+++ b/compare.go
@@ -1,7 +1,3 @@
-// Copyright 2014 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-//
 // File contains Compare functionality
 //
 // https://tools.ietf.org/html/rfc4511

--- a/conn.go
+++ b/conn.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package ldap
 
 import (

--- a/control.go
+++ b/control.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package ldap
 
 import (

--- a/dn.go
+++ b/dn.go
@@ -1,7 +1,3 @@
-// Copyright 2015 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-//
 // File contains DN parsing functionality
 //
 // https://tools.ietf.org/html/rfc4514

--- a/filter.go
+++ b/filter.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package ldap
 
 import (

--- a/ldap.go
+++ b/ldap.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package ldap
 
 import (

--- a/modify.go
+++ b/modify.go
@@ -1,7 +1,3 @@
-// Copyright 2014 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-//
 // File contains Modify functionality
 //
 // https://tools.ietf.org/html/rfc4511

--- a/search.go
+++ b/search.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-//
 // File contains Search functionality
 //
 // https://tools.ietf.org/html/rfc4511


### PR DESCRIPTION
closes #122

The repo was relicensed under MIT in https://github.com/mmitton/ldap/commit/9031c63a92b917c423331f055304e168d8f28789 but individual files still referred to the BSD license.

This picks the corrected file headers from https://github.com/mmitton/ldap/commit/5c6d51ed24aa5a12e58df30524a1008b364a0cf3