### PR TITLE
Fix control packets being encoded when none exist on bind

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -40,7 +40,9 @@ func (bindRequest *SimpleBindRequest) encode() *ber.Packet {
 	request.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, bindRequest.Username, "User Name"))
 	request.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, 0, bindRequest.Password, "Password"))
 
-	request.AppendChild(encodeControls(bindRequest.Controls))
+	if len(bindRequest.Controls) > 0 {
+		request.AppendChild(encodeControls(bindRequest.Controls))
+	}
 
 	return request
 }

--- a/del.go
+++ b/del.go
@@ -40,7 +40,7 @@ func (l *Conn) Del(delRequest *DelRequest) error {
 	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Request")
 	packet.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, l.nextMessageID(), "MessageID"))
 	packet.AppendChild(delRequest.encode())
-	if delRequest.Controls != nil {
+	if len(delRequest.Controls) > 0 {
 		packet.AppendChild(encodeControls(delRequest.Controls))
 	}
 

--- a/search.go
+++ b/search.go
@@ -375,7 +375,7 @@ func (l *Conn) Search(searchRequest *SearchRequest) (*SearchResult, error) {
 	}
 	packet.AppendChild(encodedSearchRequest)
 	// encode search controls
-	if searchRequest.Controls != nil {
+	if len(searchRequest.Controls) > 0 {
 		packet.AppendChild(encodeControls(searchRequest.Controls))
 	}
 


### PR DESCRIPTION
During the code reshuffle in #126 at bind time a call to encodeControls
was added. Unfortunately, the safety check around calling it when there
are no controls to encode were omitted from this call (unlike in del.go
and search.go). As a result the packet was always getting control
characters added even if there were none to encode.

I also modified the checks in del.go and search.go to be a little safer;
rather than check for a nil slice, it also will do the right thing when
the slice is not nil but there are no entries.