### PR TITLE
Allow order of changes in ModifyRequest to be specified

### DIFF
--- a/modify.go
+++ b/modify.go
@@ -58,54 +58,54 @@ func (p *PartialAttribute) encode() *ber.Packet {
 	return seq
 }
 
+// Change for a ModifyRequest as defined in https://tools.ietf.org/html/rfc4511
+type Change struct {
+	// Operation is the type of change to be made
+	Operation uint
+	// Modification is the attribute to be modified
+	Modification PartialAttribute
+}
+
+func (c *Change) encode() *ber.Packet {
+	change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
+	change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(c.Operation), "Operation"))
+	change.AppendChild(c.Modification.encode())
+	return change
+}
+
 // ModifyRequest as defined in https://tools.ietf.org/html/rfc4511
 type ModifyRequest struct {
 	// DN is the distinguishedName of the directory entry to modify
 	DN string
-	// AddAttributes contain the attributes to add
-	AddAttributes []PartialAttribute
-	// DeleteAttributes contain the attributes to delete
-	DeleteAttributes []PartialAttribute
-	// ReplaceAttributes contain the attributes to replace
-	ReplaceAttributes []PartialAttribute
+	// Changes contain the attributes to modify
+	Changes []Change
 }
 
-// Add inserts the given attribute to the list of attributes to add
+// Add appends the given attribute to the list of changes to be made
 func (m *ModifyRequest) Add(attrType string, attrVals []string) {
-	m.AddAttributes = append(m.AddAttributes, PartialAttribute{Type: attrType, Vals: attrVals})
+	m.appendChange(AddAttribute, attrType, attrVals)
 }
 
-// Delete inserts the given attribute to the list of attributes to delete
+// Delete appends the given attribute to the list of changes to be made
 func (m *ModifyRequest) Delete(attrType string, attrVals []string) {
-	m.DeleteAttributes = append(m.DeleteAttributes, PartialAttribute{Type: attrType, Vals: attrVals})
+	m.appendChange(DeleteAttribute, attrType, attrVals)
 }
 
-// Replace inserts the given attribute to the list of attributes to replace
+// Replace appends the given attribute to the list of changes to be made
 func (m *ModifyRequest) Replace(attrType string, attrVals []string) {
-	m.ReplaceAttributes = append(m.ReplaceAttributes, PartialAttribute{Type: attrType, Vals: attrVals})
+	m.appendChange(ReplaceAttribute, attrType, attrVals)
+}
+
+func (m *ModifyRequest) appendChange(operation uint, attrType string, attrVals []string) {
+	m.Changes = append(m.Changes, Change{operation, PartialAttribute{Type: attrType, Vals: attrVals}})
 }
 
 func (m ModifyRequest) encode() *ber.Packet {
 	request := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationModifyRequest, nil, "Modify Request")
 	request.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, m.DN, "DN"))
 	changes := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Changes")
-	for _, attribute := range m.AddAttributes {
-		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
-		change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(AddAttribute), "Operation"))
-		change.AppendChild(attribute.encode())
-		changes.AppendChild(change)
-	}
-	for _, attribute := range m.DeleteAttributes {
-		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
-		change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(DeleteAttribute), "Operation"))
-		change.AppendChild(attribute.encode())
-		changes.AppendChild(change)
-	}
-	for _, attribute := range m.ReplaceAttributes {
-		change := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Change")
-		change.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, uint64(ReplaceAttribute), "Operation"))
-		change.AppendChild(attribute.encode())
-		changes.AppendChild(change)
+	for _, change := range m.Changes {
+		changes.AppendChild(change.encode())
 	}
 	request.AppendChild(changes)
 	return request


### PR DESCRIPTION
Updates ModifyRequest to allow the order of changes to be specified rather than grouped by operation.

As defined in [rfc4511](https://tools.ietf.org/html/rfc4511#section-4.6):
```
- changes: A list of modifications to be performed on the entry.  The
     entire list of modifications MUST be performed in the order they
     are listed as a single atomic operation.
```