### PR TITLE
Add an initial Contributions Guideline document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contribution Guidelines
+
+We welcome contribution and improvements.
+
+## Guiding Principles
+
+To begin with here is a draft from an email exchange:
+
+ * take compatibility seriously (our semvers, compatibility with older go versions, etc)
+ * don't tag untested code for release
+ * beware of baking in implicit behavior based on other libraries/tools choices
+ * be as high-fidelity as possible in plumbing through LDAP data (don't mask errors or reduce power of someone using the library)


### PR DESCRIPTION
Let's expand this document with our Contribution Guidelines and processes.