### PR TITLE
Fix unittests pointing to the external package "gopkg.in/ldap.v2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
 go_import_path: gopkg.in/ldap.v2
 install:
     - go get gopkg.in/asn1-ber.v1
-    - go get gopkg.in/ldap.v2
     - go get code.google.com/p/go.tools/cmd/cover || go get golang.org/x/tools/cmd/cover
     - go get github.com/golang/lint/golint || true
     - go build -v ./...

--- a/dn_test.go
+++ b/dn_test.go
@@ -1,56 +1,54 @@
-package ldap_test
+package ldap
 
 import (
 	"reflect"
 	"testing"
-
-	"gopkg.in/ldap.v2"
 )
 
 func TestSuccessfulDNParsing(t *testing.T) {
-	testcases := map[string]ldap.DN{
-		"": ldap.DN{[]*ldap.RelativeDN{}},
-		"cn=Jim\\2C \\22Hasse Hö\\22 Hansson!,dc=dummy,dc=com": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"cn", "Jim, \"Hasse Hö\" Hansson!"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"dc", "dummy"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"dc", "com"}}}}},
-		"UID=jsmith,DC=example,DC=net": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"UID", "jsmith"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "example"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
-		"OU=Sales+CN=J. Smith,DC=example,DC=net": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{
-				&ldap.AttributeTypeAndValue{"OU", "Sales"},
-				&ldap.AttributeTypeAndValue{"CN", "J. Smith"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "example"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
-		"1.3.6.1.4.1.1466.0=#04024869": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"}}}}},
-		"1.3.6.1.4.1.1466.0=#04024869,DC=net": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"DC", "net"}}}}},
-		"CN=Lu\\C4\\8Di\\C4\\87": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"CN", "Lučić"}}}}},
-		"  CN  =  Lu\\C4\\8Di\\C4\\87  ": ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"CN", "Lučić"}}}}},
-		`   A   =   1   ,   B   =   2   `: ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"A", "1"}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"B", "2"}}}}},
-		`   A   =   1   +   B   =   2   `: ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{
-				&ldap.AttributeTypeAndValue{"A", "1"},
-				&ldap.AttributeTypeAndValue{"B", "2"}}}}},
-		`   \ \ A\ \    =   \ \ 1\ \    ,   \ \ B\ \    =   \ \ 2\ \    `: ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"  A  ", "  1  "}}},
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{&ldap.AttributeTypeAndValue{"  B  ", "  2  "}}}}},
-		`   \ \ A\ \    =   \ \ 1\ \    +   \ \ B\ \    =   \ \ 2\ \    `: ldap.DN{[]*ldap.RelativeDN{
-			&ldap.RelativeDN{[]*ldap.AttributeTypeAndValue{
-				&ldap.AttributeTypeAndValue{"  A  ", "  1  "},
-				&ldap.AttributeTypeAndValue{"  B  ", "  2  "}}}}},
+	testcases := map[string]DN{
+		"": DN{[]*RelativeDN{}},
+		"cn=Jim\\2C \\22Hasse Hö\\22 Hansson!,dc=dummy,dc=com": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"cn", "Jim, \"Hasse Hö\" Hansson!"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"dc", "dummy"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"dc", "com"}}}}},
+		"UID=jsmith,DC=example,DC=net": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"UID", "jsmith"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "example"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "net"}}}}},
+		"OU=Sales+CN=J. Smith,DC=example,DC=net": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{
+				&AttributeTypeAndValue{"OU", "Sales"},
+				&AttributeTypeAndValue{"CN", "J. Smith"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "example"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "net"}}}}},
+		"1.3.6.1.4.1.1466.0=#04024869": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"}}}}},
+		"1.3.6.1.4.1.1466.0=#04024869,DC=net": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"1.3.6.1.4.1.1466.0", "Hi"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"DC", "net"}}}}},
+		"CN=Lu\\C4\\8Di\\C4\\87": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"CN", "Lučić"}}}}},
+		"  CN  =  Lu\\C4\\8Di\\C4\\87  ": DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"CN", "Lučić"}}}}},
+		`   A   =   1   ,   B   =   2   `: DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"A", "1"}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"B", "2"}}}}},
+		`   A   =   1   +   B   =   2   `: DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{
+				&AttributeTypeAndValue{"A", "1"},
+				&AttributeTypeAndValue{"B", "2"}}}}},
+		`   \ \ A\ \    =   \ \ 1\ \    ,   \ \ B\ \    =   \ \ 2\ \    `: DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"  A  ", "  1  "}}},
+			&RelativeDN{[]*AttributeTypeAndValue{&AttributeTypeAndValue{"  B  ", "  2  "}}}}},
+		`   \ \ A\ \    =   \ \ 1\ \    +   \ \ B\ \    =   \ \ 2\ \    `: DN{[]*RelativeDN{
+			&RelativeDN{[]*AttributeTypeAndValue{
+				&AttributeTypeAndValue{"  A  ", "  1  "},
+				&AttributeTypeAndValue{"  B  ", "  2  "}}}}},
 	}
 
 	for test, answer := range testcases {
-		dn, err := ldap.ParseDN(test)
+		dn, err := ParseDN(test)
 		if err != nil {
 			t.Errorf(err.Error())
 			continue
@@ -85,7 +83,7 @@ func TestErrorDNParsing(t *testing.T) {
 	}
 
 	for test, answer := range testcases {
-		_, err := ldap.ParseDN(test)
+		_, err := ParseDN(test)
 		if err == nil {
 			t.Errorf("Expected %s to fail parsing but succeeded\n", test)
 		} else if err.Error() != answer {
@@ -152,12 +150,12 @@ func TestDNEqual(t *testing.T) {
 	}
 
 	for i, tc := range testcases {
-		a, err := ldap.ParseDN(tc.A)
+		a, err := ParseDN(tc.A)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
 		}
-		b, err := ldap.ParseDN(tc.B)
+		b, err := ParseDN(tc.B)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
@@ -193,12 +191,12 @@ func TestDNAncestor(t *testing.T) {
 	}
 
 	for i, tc := range testcases {
-		a, err := ldap.ParseDN(tc.A)
+		a, err := ParseDN(tc.A)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
 		}
-		b, err := ldap.ParseDN(tc.B)
+		b, err := ParseDN(tc.B)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue

--- a/example_test.go
+++ b/example_test.go
@@ -1,17 +1,15 @@
-package ldap_test
+package ldap
 
 import (
 	"crypto/tls"
 	"fmt"
 	"log"
-
-	"gopkg.in/ldap.v2"
 )
 
 // ExampleConn_Bind demonstrates how to bind a connection to an ldap user
 // allowing access to restricted attributes that user has access to
 func ExampleConn_Bind() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -25,15 +23,15 @@ func ExampleConn_Bind() {
 
 // ExampleConn_Search demonstrates how to use the search interface
 func ExampleConn_Search() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer l.Close()
 
-	searchRequest := ldap.NewSearchRequest(
+	searchRequest := NewSearchRequest(
 		"dc=example,dc=com", // The base dn to search
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		ScopeWholeSubtree, NeverDerefAliases, 0, 0, false,
 		"(&(objectClass=organizationalPerson))", // The filter to apply
 		[]string{"dn", "cn"},                    // A list attributes to retrieve
 		nil,
@@ -51,7 +49,7 @@ func ExampleConn_Search() {
 
 // ExampleStartTLS demonstrates how to start a TLS connection
 func ExampleConn_StartTLS() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,7 +66,7 @@ func ExampleConn_StartTLS() {
 
 // ExampleConn_Compare demonstrates how to compare an attribute with a value
 func ExampleConn_Compare() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -83,7 +81,7 @@ func ExampleConn_Compare() {
 }
 
 func ExampleConn_PasswordModify_admin() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,7 +92,7 @@ func ExampleConn_PasswordModify_admin() {
 		log.Fatal(err)
 	}
 
-	passwordModifyRequest := ldap.NewPasswordModifyRequest("cn=user,dc=example,dc=com", "", "NewPassword")
+	passwordModifyRequest := NewPasswordModifyRequest("cn=user,dc=example,dc=com", "", "NewPassword")
 	_, err = l.PasswordModify(passwordModifyRequest)
 
 	if err != nil {
@@ -103,7 +101,7 @@ func ExampleConn_PasswordModify_admin() {
 }
 
 func ExampleConn_PasswordModify_generatedPassword() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -114,7 +112,7 @@ func ExampleConn_PasswordModify_generatedPassword() {
 		log.Fatal(err)
 	}
 
-	passwordModifyRequest := ldap.NewPasswordModifyRequest("", "OldPassword", "")
+	passwordModifyRequest := NewPasswordModifyRequest("", "OldPassword", "")
 	passwordModifyResponse, err := l.PasswordModify(passwordModifyRequest)
 	if err != nil {
 		log.Fatalf("Password could not be changed: %s", err.Error())
@@ -125,7 +123,7 @@ func ExampleConn_PasswordModify_generatedPassword() {
 }
 
 func ExampleConn_PasswordModify_setNewPassword() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -136,7 +134,7 @@ func ExampleConn_PasswordModify_setNewPassword() {
 		log.Fatal(err)
 	}
 
-	passwordModifyRequest := ldap.NewPasswordModifyRequest("", "OldPassword", "NewPassword")
+	passwordModifyRequest := NewPasswordModifyRequest("", "OldPassword", "NewPassword")
 	_, err = l.PasswordModify(passwordModifyRequest)
 
 	if err != nil {
@@ -145,14 +143,14 @@ func ExampleConn_PasswordModify_setNewPassword() {
 }
 
 func ExampleConn_Modify() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer l.Close()
 
 	// Add a description, and replace the mail attributes
-	modify := ldap.NewModifyRequest("cn=user,dc=example,dc=com", nil)
+	modify := NewModifyRequest("cn=user,dc=example,dc=com", nil)
 	modify.Add("description", []string{"An example user"})
 	modify.Replace("mail", []string{"user@example.org"})
 
@@ -171,7 +169,7 @@ func Example_userAuthentication() {
 	bindusername := "readonly"
 	bindpassword := "password"
 
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -190,9 +188,9 @@ func Example_userAuthentication() {
 	}
 
 	// Search for the given username
-	searchRequest := ldap.NewSearchRequest(
+	searchRequest := NewSearchRequest(
 		"dc=example,dc=com",
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		ScopeWholeSubtree, NeverDerefAliases, 0, 0, false,
 		fmt.Sprintf("(&(objectClass=organizationalPerson)(uid=%s))", username),
 		[]string{"dn"},
 		nil,
@@ -223,22 +221,22 @@ func Example_userAuthentication() {
 }
 
 func Example_beherappolicy() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer l.Close()
 
-	controls := []ldap.Control{}
-	controls = append(controls, ldap.NewControlBeheraPasswordPolicy())
-	bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=example,dc=com", "password", controls)
+	controls := []Control{}
+	controls = append(controls, NewControlBeheraPasswordPolicy())
+	bindRequest := NewSimpleBindRequest("cn=admin,dc=example,dc=com", "password", controls)
 
 	r, err := l.SimpleBind(bindRequest)
-	ppolicyControl := ldap.FindControl(r.Controls, ldap.ControlTypeBeheraPasswordPolicy)
+	ppolicyControl := FindControl(r.Controls, ControlTypeBeheraPasswordPolicy)
 
-	var ppolicy *ldap.ControlBeheraPasswordPolicy
+	var ppolicy *ControlBeheraPasswordPolicy
 	if ppolicyControl != nil {
-		ppolicy = ppolicyControl.(*ldap.ControlBeheraPasswordPolicy)
+		ppolicy = ppolicyControl.(*ControlBeheraPasswordPolicy)
 	} else {
 		log.Printf("ppolicyControl response not available.\n")
 	}
@@ -262,32 +260,32 @@ func Example_beherappolicy() {
 }
 
 func Example_vchuppolicy() {
-	l, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer l.Close()
 	l.Debug = true
 
-	bindRequest := ldap.NewSimpleBindRequest("cn=admin,dc=example,dc=com", "password", nil)
+	bindRequest := NewSimpleBindRequest("cn=admin,dc=example,dc=com", "password", nil)
 
 	r, err := l.SimpleBind(bindRequest)
 
-	passwordMustChangeControl := ldap.FindControl(r.Controls, ldap.ControlTypeVChuPasswordMustChange)
-	var passwordMustChange *ldap.ControlVChuPasswordMustChange
+	passwordMustChangeControl := FindControl(r.Controls, ControlTypeVChuPasswordMustChange)
+	var passwordMustChange *ControlVChuPasswordMustChange
 	if passwordMustChangeControl != nil {
-		passwordMustChange = passwordMustChangeControl.(*ldap.ControlVChuPasswordMustChange)
+		passwordMustChange = passwordMustChangeControl.(*ControlVChuPasswordMustChange)
 	}
 
 	if passwordMustChange != nil && passwordMustChange.MustChange {
 		log.Printf("Password Must be changed.\n")
 	}
 
-	passwordWarningControl := ldap.FindControl(r.Controls, ldap.ControlTypeVChuPasswordWarning)
+	passwordWarningControl := FindControl(r.Controls, ControlTypeVChuPasswordWarning)
 
-	var passwordWarning *ldap.ControlVChuPasswordWarning
+	var passwordWarning *ControlVChuPasswordWarning
 	if passwordWarningControl != nil {
-		passwordWarning = passwordWarningControl.(*ldap.ControlVChuPasswordWarning)
+		passwordWarning = passwordWarningControl.(*ControlVChuPasswordWarning)
 	} else {
 		log.Printf("ppolicyControl response not available.\n")
 	}
@@ -307,7 +305,7 @@ func Example_vchuppolicy() {
 // This example demonstrates how to use ControlPaging to manually execute a
 // paginated search request instead of using SearchWithPaging.
 func ExampleControlPaging_manualPaging() {
-	conn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
+	conn, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -316,12 +314,12 @@ func ExampleControlPaging_manualPaging() {
 	var pageSize uint32 = 32
 	searchBase := "dc=example,dc=com"
 	filter := "(objectClass=group)"
-	pagingControl := ldap.NewControlPaging(pageSize)
+	pagingControl := NewControlPaging(pageSize)
 	attributes := []string{}
-	controls := []ldap.Control{pagingControl}
+	controls := []Control{pagingControl}
 
 	for {
-		request := ldap.NewSearchRequest(searchBase, ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false, filter, attributes, controls)
+		request := NewSearchRequest(searchBase, ScopeWholeSubtree, DerefAlways, 0, 0, false, filter, attributes, controls)
 		response, err := conn.Search(request)
 		if err != nil {
 			log.Fatalf("Failed to execute search request: %s", err.Error())
@@ -332,8 +330,8 @@ func ExampleControlPaging_manualPaging() {
 		// In order to prepare the next request, we check if the response
 		// contains another ControlPaging object and a not-empty cookie and
 		// copy that cookie into our pagingControl object:
-		updatedControl := ldap.FindControl(response.Controls, ldap.ControlTypePaging)
-		if ctrl, ok := updatedControl.(*ldap.ControlPaging); ctrl != nil && ok && len(ctrl.Cookie) != 0 {
+		updatedControl := FindControl(response.Controls, ControlTypePaging)
+		if ctrl, ok := updatedControl.(*ControlPaging); ctrl != nil && ok && len(ctrl.Cookie) != 0 {
 			pagingControl.SetCookie(ctrl.Cookie)
 			continue
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,7 @@ import (
 // ExampleConn_Bind demonstrates how to bind a connection to an ldap user
 // allowing access to restricted attributes that user has access to
 func ExampleConn_Bind() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -23,7 +23,7 @@ func ExampleConn_Bind() {
 
 // ExampleConn_Search demonstrates how to use the search interface
 func ExampleConn_Search() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func ExampleConn_Search() {
 
 // ExampleStartTLS demonstrates how to start a TLS connection
 func ExampleConn_StartTLS() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func ExampleConn_StartTLS() {
 
 // ExampleConn_Compare demonstrates how to compare an attribute with a value
 func ExampleConn_Compare() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func ExampleConn_Compare() {
 }
 
 func ExampleConn_PasswordModify_admin() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func ExampleConn_PasswordModify_admin() {
 }
 
 func ExampleConn_PasswordModify_generatedPassword() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func ExampleConn_PasswordModify_generatedPassword() {
 }
 
 func ExampleConn_PasswordModify_setNewPassword() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func ExampleConn_PasswordModify_setNewPassword() {
 }
 
 func ExampleConn_Modify() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func Example_userAuthentication() {
 	bindusername := "readonly"
 	bindpassword := "password"
 
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func Example_userAuthentication() {
 }
 
 func Example_beherappolicy() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func Example_beherappolicy() {
 }
 
 func Example_vchuppolicy() {
-	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -305,7 +305,7 @@ func Example_vchuppolicy() {
 // This example demonstrates how to use ControlPaging to manually execute a
 // paginated search request instead of using SearchWithPaging.
 func ExampleControlPaging_manualPaging() {
-	conn, err := Dial("tcp", fmt.Sprintf("%s:%d", "example.com", 389))
+	conn, err := Dial("tcp", fmt.Sprintf("%s:%d", "ldap.example.com", 389))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,11 +1,10 @@
-package ldap_test
+package ldap
 
 import (
 	"strings"
 	"testing"
 
 	"gopkg.in/asn1-ber.v1"
-	"gopkg.in/ldap.v2"
 )
 
 type compileTest struct {
@@ -20,104 +19,104 @@ var testFilters = []compileTest{
 	compileTest{
 		filterStr:      "(&(sn=Miller)(givenName=Bob))",
 		expectedFilter: "(&(sn=Miller)(givenName=Bob))",
-		expectedType:   ldap.FilterAnd,
+		expectedType:   FilterAnd,
 	},
 	compileTest{
 		filterStr:      "(|(sn=Miller)(givenName=Bob))",
 		expectedFilter: "(|(sn=Miller)(givenName=Bob))",
-		expectedType:   ldap.FilterOr,
+		expectedType:   FilterOr,
 	},
 	compileTest{
 		filterStr:      "(!(sn=Miller))",
 		expectedFilter: "(!(sn=Miller))",
-		expectedType:   ldap.FilterNot,
+		expectedType:   FilterNot,
 	},
 	compileTest{
 		filterStr:      "(sn=Miller)",
 		expectedFilter: "(sn=Miller)",
-		expectedType:   ldap.FilterEqualityMatch,
+		expectedType:   FilterEqualityMatch,
 	},
 	compileTest{
 		filterStr:      "(sn=Mill*)",
 		expectedFilter: "(sn=Mill*)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn=*Mill)",
 		expectedFilter: "(sn=*Mill)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn=*Mill*)",
 		expectedFilter: "(sn=*Mill*)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn=*i*le*)",
 		expectedFilter: "(sn=*i*le*)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn=Mi*l*r)",
 		expectedFilter: "(sn=Mi*l*r)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	// substring filters escape properly
 	compileTest{
 		filterStr:      `(sn=Mi*함*r)`,
 		expectedFilter: `(sn=Mi*\ed\95\a8*r)`,
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	// already escaped substring filters don't get double-escaped
 	compileTest{
 		filterStr:      `(sn=Mi*\ed\95\a8*r)`,
 		expectedFilter: `(sn=Mi*\ed\95\a8*r)`,
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn=Mi*le*)",
 		expectedFilter: "(sn=Mi*le*)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn=*i*ler)",
 		expectedFilter: "(sn=*i*ler)",
-		expectedType:   ldap.FilterSubstrings,
+		expectedType:   FilterSubstrings,
 	},
 	compileTest{
 		filterStr:      "(sn>=Miller)",
 		expectedFilter: "(sn>=Miller)",
-		expectedType:   ldap.FilterGreaterOrEqual,
+		expectedType:   FilterGreaterOrEqual,
 	},
 	compileTest{
 		filterStr:      "(sn<=Miller)",
 		expectedFilter: "(sn<=Miller)",
-		expectedType:   ldap.FilterLessOrEqual,
+		expectedType:   FilterLessOrEqual,
 	},
 	compileTest{
 		filterStr:      "(sn=*)",
 		expectedFilter: "(sn=*)",
-		expectedType:   ldap.FilterPresent,
+		expectedType:   FilterPresent,
 	},
 	compileTest{
 		filterStr:      "(sn~=Miller)",
 		expectedFilter: "(sn~=Miller)",
-		expectedType:   ldap.FilterApproxMatch,
+		expectedType:   FilterApproxMatch,
 	},
 	compileTest{
 		filterStr:      `(objectGUID='\fc\fe\a3\ab\f9\90N\aaGm\d5I~\d12)`,
 		expectedFilter: `(objectGUID='\fc\fe\a3\ab\f9\90N\aaGm\d5I~\d12)`,
-		expectedType:   ldap.FilterEqualityMatch,
+		expectedType:   FilterEqualityMatch,
 	},
 	compileTest{
 		filterStr:      `(objectGUID=абвгдеёжзийклмнопрстуфхцчшщъыьэюя)`,
 		expectedFilter: `(objectGUID=\d0\b0\d0\b1\d0\b2\d0\b3\d0\b4\d0\b5\d1\91\d0\b6\d0\b7\d0\b8\d0\b9\d0\ba\d0\bb\d0\bc\d0\bd\d0\be\d0\bf\d1\80\d1\81\d1\82\d1\83\d1\84\d1\85\d1\86\d1\87\d1\88\d1\89\d1\8a\d1\8b\d1\8c\d1\8d\d1\8e\d1\8f)`,
-		expectedType:   ldap.FilterEqualityMatch,
+		expectedType:   FilterEqualityMatch,
 	},
 	compileTest{
 		filterStr:      `(objectGUID=함수목록)`,
 		expectedFilter: `(objectGUID=\ed\95\a8\ec\88\98\eb\aa\a9\eb\a1\9d)`,
-		expectedType:   ldap.FilterEqualityMatch,
+		expectedType:   FilterEqualityMatch,
 	},
 	compileTest{
 		filterStr:      `(objectGUID=`,
@@ -146,42 +145,42 @@ var testFilters = []compileTest{
 	compileTest{
 		filterStr:      `(memberOf:=foo)`,
 		expectedFilter: `(memberOf:=foo)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 	// attr+named matching rule extension
 	compileTest{
 		filterStr:      `(memberOf:test:=foo)`,
 		expectedFilter: `(memberOf:test:=foo)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 	// attr+oid matching rule extension
 	compileTest{
 		filterStr:      `(cn:1.2.3.4.5:=Fred Flintstone)`,
 		expectedFilter: `(cn:1.2.3.4.5:=Fred Flintstone)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 	// attr+dn+oid matching rule extension
 	compileTest{
 		filterStr:      `(sn:dn:2.4.6.8.10:=Barney Rubble)`,
 		expectedFilter: `(sn:dn:2.4.6.8.10:=Barney Rubble)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 	// attr+dn extension
 	compileTest{
 		filterStr:      `(o:dn:=Ace Industry)`,
 		expectedFilter: `(o:dn:=Ace Industry)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 	// dn extension
 	compileTest{
 		filterStr:      `(:dn:2.4.6.8.10:=Dino)`,
 		expectedFilter: `(:dn:2.4.6.8.10:=Dino)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 	compileTest{
 		filterStr:      `(memberOf:1.2.840.113556.1.4.1941:=CN=User1,OU=blah,DC=mydomain,DC=net)`,
 		expectedFilter: `(memberOf:1.2.840.113556.1.4.1941:=CN=User1,OU=blah,DC=mydomain,DC=net)`,
-		expectedType:   ldap.FilterExtensibleMatch,
+		expectedType:   FilterExtensibleMatch,
 	},
 
 	// compileTest{ filterStr: "()", filterType: FilterExtensibleMatch },
@@ -195,15 +194,15 @@ var testInvalidFilters = []string{
 func TestFilter(t *testing.T) {
 	// Test Compiler and Decompiler
 	for _, i := range testFilters {
-		filter, err := ldap.CompileFilter(i.filterStr)
+		filter, err := CompileFilter(i.filterStr)
 		if err != nil {
 			if i.expectedErr == "" || !strings.Contains(err.Error(), i.expectedErr) {
 				t.Errorf("Problem compiling '%s' - '%v' (expected error to contain '%v')", i.filterStr, err, i.expectedErr)
 			}
 		} else if filter.Tag != ber.Tag(i.expectedType) {
-			t.Errorf("%q Expected %q got %q", i.filterStr, ldap.FilterMap[uint64(i.expectedType)], ldap.FilterMap[uint64(filter.Tag)])
+			t.Errorf("%q Expected %q got %q", i.filterStr, FilterMap[uint64(i.expectedType)], FilterMap[uint64(filter.Tag)])
 		} else {
-			o, err := ldap.DecompileFilter(filter)
+			o, err := DecompileFilter(filter)
 			if err != nil {
 				t.Errorf("Problem compiling %s - %s", i.filterStr, err.Error())
 			} else if i.expectedFilter != o {
@@ -215,7 +214,7 @@ func TestFilter(t *testing.T) {
 
 func TestInvalidFilter(t *testing.T) {
 	for _, filterStr := range testInvalidFilters {
-		if _, err := ldap.CompileFilter(filterStr); err == nil {
+		if _, err := CompileFilter(filterStr); err == nil {
 			t.Errorf("Problem compiling %s - expected err", filterStr)
 		}
 	}
@@ -233,7 +232,7 @@ func BenchmarkFilterCompile(b *testing.B) {
 	maxIdx := len(filters)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		ldap.CompileFilter(filters[i%maxIdx])
+		CompileFilter(filters[i%maxIdx])
 	}
 }
 
@@ -243,12 +242,12 @@ func BenchmarkFilterDecompile(b *testing.B) {
 
 	// Test Compiler and Decompiler
 	for idx, i := range testFilters {
-		filters[idx], _ = ldap.CompileFilter(i.filterStr)
+		filters[idx], _ = CompileFilter(i.filterStr)
 	}
 
 	maxIdx := len(filters)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		ldap.DecompileFilter(filters[i%maxIdx])
+		DecompileFilter(filters[i%maxIdx])
 	}
 }

--- a/moddn_test.go
+++ b/moddn_test.go
@@ -1,20 +1,18 @@
-package ldap_test
+package ldap
 
 import (
 	"log"
-
-	"gopkg.in/ldap.v2"
 )
 
 // ExampleConn_ModifyDN_renameNoMove shows how to rename an entry without moving it
 func ExampleConn_ModifyDN_renameNoMove() {
-	conn, err := ldap.Dial("tcp", "ldap.example.org:389")
+	conn, err := Dial("tcp", "example.org:389")
 	if err != nil {
 		log.Fatalf("Failed to connect: %s\n", err)
 	}
 	defer conn.Close()
 
-	_, err = conn.SimpleBind(&ldap.SimpleBindRequest{
+	_, err = conn.SimpleBind(&SimpleBindRequest{
 		Username: "uid=someone,ou=people,dc=example,dc=org",
 		Password: "MySecretPass",
 	})
@@ -22,7 +20,7 @@ func ExampleConn_ModifyDN_renameNoMove() {
 		log.Fatalf("Failed to bind: %s\n", err)
 	}
 	// just rename to uid=new,ou=people,dc=example,dc=org:
-	req := ldap.NewModifyDNRequest("uid=user,ou=people,dc=example,dc=org", "uid=new", true, "")
+	req := NewModifyDNRequest("uid=user,ou=people,dc=example,dc=org", "uid=new", true, "")
 	if err = conn.ModifyDN(req); err != nil {
 		log.Fatalf("Failed to call ModifyDN(): %s\n", err)
 	}
@@ -30,13 +28,13 @@ func ExampleConn_ModifyDN_renameNoMove() {
 
 // ExampleConn_ModifyDN_renameAndMove shows how to rename an entry and moving it to a new base
 func ExampleConn_ModifyDN_renameAndMove() {
-	conn, err := ldap.Dial("tcp", "ldap.example.org:389")
+	conn, err := Dial("tcp", "example.org:389")
 	if err != nil {
 		log.Fatalf("Failed to connect: %s\n", err)
 	}
 	defer conn.Close()
 
-	_, err = conn.SimpleBind(&ldap.SimpleBindRequest{
+	_, err = conn.SimpleBind(&SimpleBindRequest{
 		Username: "uid=someone,ou=people,dc=example,dc=org",
 		Password: "MySecretPass",
 	})
@@ -45,7 +43,7 @@ func ExampleConn_ModifyDN_renameAndMove() {
 	}
 	// rename to uid=new,ou=people,dc=example,dc=org and move to ou=users,dc=example,dc=org ->
 	// uid=new,ou=users,dc=example,dc=org
-	req := ldap.NewModifyDNRequest("uid=user,ou=people,dc=example,dc=org", "uid=new", true, "ou=users,dc=example,dc=org")
+	req := NewModifyDNRequest("uid=user,ou=people,dc=example,dc=org", "uid=new", true, "ou=users,dc=example,dc=org")
 
 	if err = conn.ModifyDN(req); err != nil {
 		log.Fatalf("Failed to call ModifyDN(): %s\n", err)
@@ -54,13 +52,13 @@ func ExampleConn_ModifyDN_renameAndMove() {
 
 // ExampleConn_ModifyDN_moveOnly shows how to move an entry to a new base without renaming the RDN
 func ExampleConn_ModifyDN_moveOnly() {
-	conn, err := ldap.Dial("tcp", "ldap.example.org:389")
+	conn, err := Dial("tcp", "example.org:389")
 	if err != nil {
 		log.Fatalf("Failed to connect: %s\n", err)
 	}
 	defer conn.Close()
 
-	_, err = conn.SimpleBind(&ldap.SimpleBindRequest{
+	_, err = conn.SimpleBind(&SimpleBindRequest{
 		Username: "uid=someone,ou=people,dc=example,dc=org",
 		Password: "MySecretPass",
 	})
@@ -68,7 +66,7 @@ func ExampleConn_ModifyDN_moveOnly() {
 		log.Fatalf("Failed to bind: %s\n", err)
 	}
 	// move to ou=users,dc=example,dc=org -> uid=user,ou=users,dc=example,dc=org
-	req := ldap.NewModifyDNRequest("uid=user,ou=people,dc=example,dc=org", "uid=user", true, "ou=users,dc=example,dc=org")
+	req := NewModifyDNRequest("uid=user,ou=people,dc=example,dc=org", "uid=user", true, "ou=users,dc=example,dc=org")
 	if err = conn.ModifyDN(req); err != nil {
 		log.Fatalf("Failed to call ModifyDN(): %s\n", err)
 	}

--- a/moddn_test.go
+++ b/moddn_test.go
@@ -6,7 +6,7 @@ import (
 
 // ExampleConn_ModifyDN_renameNoMove shows how to rename an entry without moving it
 func ExampleConn_ModifyDN_renameNoMove() {
-	conn, err := Dial("tcp", "example.org:389")
+	conn, err := Dial("tcp", "ldap.example.org:389")
 	if err != nil {
 		log.Fatalf("Failed to connect: %s\n", err)
 	}
@@ -28,7 +28,7 @@ func ExampleConn_ModifyDN_renameNoMove() {
 
 // ExampleConn_ModifyDN_renameAndMove shows how to rename an entry and moving it to a new base
 func ExampleConn_ModifyDN_renameAndMove() {
-	conn, err := Dial("tcp", "example.org:389")
+	conn, err := Dial("tcp", "ldap.example.org:389")
 	if err != nil {
 		log.Fatalf("Failed to connect: %s\n", err)
 	}
@@ -52,7 +52,7 @@ func ExampleConn_ModifyDN_renameAndMove() {
 
 // ExampleConn_ModifyDN_moveOnly shows how to move an entry to a new base without renaming the RDN
 func ExampleConn_ModifyDN_moveOnly() {
-	conn, err := Dial("tcp", "example.org:389")
+	conn, err := Dial("tcp", "ldap.example.org:389")
 	if err != nil {
 		log.Fatalf("Failed to connect: %s\n", err)
 	}


### PR DESCRIPTION
Some of the *_test.go files are pointing to the external package "gopkg.in/ldap.v2". This is not the expected behavior of unittests and it is not consistent with other unittests inside the library.