### PR TITLE
Stop Compare causing "Error decoding ldap message"

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -37,7 +37,7 @@ func (l *Conn) Compare(dn, attribute, value string) (bool, error) {
 
 	ava := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "AttributeValueAssertion")
 	ava.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, attribute, "AttributeDesc"))
-	ava.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagOctetString, value, "AssertionValue"))
+	ava.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, value, "AssertionValue"))
 	request.AppendChild(ava)
 	packet.AppendChild(request)
 


### PR DESCRIPTION
Fixes https://github.com/go-ldap/ldap/issues/139

Without the patch I get

```
2018/08/07 14:59:47 Received unexpected message 0, false
LDAP Response: (Universal, Constructed, Sequence and Sequence of) Len=122 "<nil>"
 Message ID: (Universal, Primitive, Integer) Len=1 "0"
 Extended Response: (Application, Constructed, 0x18) Len=93 "<nil>"
  (Universal, Primitive, Enumerated) Len=1 "2"
  (Universal, Primitive, Octet String) Len=0 ""
  (Universal, Primitive, Octet String) Len=86 "00000057: LdapErr: DSID-0C0C0F50, comment: Error decoding ldap message, data 0, v3839\x00"
 (Context, Primitive, 0x0A) Len=22 "<nil>"
(bool) false
(*errors.errorString)(0xc42014fa90)(unable to read LDAP response packet: unexpected EOF)
LDAP Result Code 200 "": ldap: connection closed
```