### PR TITLE
conn: Ensure 64-bit alignment for atomics on 32-bit platforms

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -85,6 +85,9 @@ const (
 
 // Conn represents an LDAP Connection
 type Conn struct {
+	// requestTimeout is loaded atomically
+	// so we need to ensure 64-bit alignment on 32-bit platforms.
+	requestTimeout      int64
 	conn                net.Conn
 	isTLS               bool
 	closing             uint32
@@ -98,7 +101,6 @@ type Conn struct {
 	wgClose             sync.WaitGroup
 	outstandingRequests uint
 	messageMutex        sync.Mutex
-	requestTimeout      int64
 }
 
 var _ Client = &Conn{}


### PR DESCRIPTION
# Summary
As it currently stands, there is no guarantee that the requestTimeout variable on a Conn structure is going to be aligned to a 64-bit boundary. As golang/go#599 is not fixed as of yet, it is still the caller's responsibility to ensure that is the case.

This pull request should resolve issues #185 and #195 by moving requestTimeout to the very beginning of the structure. The alternative would be to manually pad the structure, and that offers no guarantees of no regression occurring due to the length of the structure changing in future versions.