### PR TITLE
Add ldap.TLSConnectionState()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -295,6 +295,17 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 	return nil
 }
 
+// TLSConnectionState returns the client's TLS connection state.
+// The return values are their zero values if StartTLS did
+// not succeed.
+func (l *Conn) TLSConnectionState() (state tls.ConnectionState, ok bool) {
+	tc, ok := l.conn.(*tls.Conn)
+	if !ok {
+		return
+	}
+	return tc.ConnectionState(), true
+}
+
 func (l *Conn) sendMessage(packet *ber.Packet) (*messageContext, error) {
 	return l.sendMessageWithFlags(packet, 0)
 }

--- a/ldap_test.go
+++ b/ldap_test.go
@@ -56,6 +56,30 @@ func TestStartTLS(t *testing.T) {
 	fmt.Printf("TestStartTLS: finished...\n")
 }
 
+func TestTLSConnectionState(t *testing.T) {
+	fmt.Printf("TestTLSConnectionState: starting...\n")
+	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	cs, ok := l.TLSConnectionState()
+	if !ok {
+		t.Errorf("TLSConnectionState returned ok == false; want true")
+	}
+	if cs.Version == 0 || !cs.HandshakeComplete {
+		t.Errorf("ConnectionState = %#v; expected Version != 0 and HandshakeComplete = true", cs)
+	}
+
+	fmt.Printf("TestTLSConnectionState: finished...\n")
+}
+
 func TestSearch(t *testing.T) {
 	fmt.Printf("TestSearch: starting...\n")
 	l, err := Dial("tcp", fmt.Sprintf("%s:%d", ldapServer, ldapPort))


### PR DESCRIPTION
This change exposes the internal tls connection state, following the pattern taken by `net/smtp`: https://golang.org/pkg/net/smtp/#Client.TLSConnectionState

This makes it possible to inspect the certificate chain returned by ldap servers that only offer StartTLS. For example, I just used my fork to make a quick cli tool to help with maintenance on the certificates of some OpenLDAP instances.