### PR TITLE
Added check for ControlValue string check

### DIFF
--- a/control.go
+++ b/control.go
@@ -63,7 +63,9 @@ func (c *ControlString) Encode() *ber.Packet {
 	if c.Criticality {
 		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
 	}
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, string(c.ControlValue), "Control Value"))
+	if c.ControlValue != "" {
+		packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, string(c.ControlValue), "Control Value"))
+	}
 	return packet
 }
 

--- a/control_test.go
+++ b/control_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"gopkg.in/asn1-ber.v1"
+	ber "gopkg.in/asn1-ber.v1"
 )
 
 func TestControlPaging(t *testing.T) {
@@ -95,9 +95,9 @@ func TestDescribeControlMicrosoftShowDeleted(t *testing.T) {
 
 func TestDescribeControlString(t *testing.T) {
 	runAddControlDescriptions(t, NewControlString("x", true, "y"), "Control Type ()", "Criticality", "Control Value")
-	runAddControlDescriptions(t, NewControlString("x", true, ""), "Control Type ()", "Criticality", "Control Value")
+	runAddControlDescriptions(t, NewControlString("x", true, ""), "Control Type ()", "Criticality")
 	runAddControlDescriptions(t, NewControlString("x", false, "y"), "Control Type ()", "Control Value")
-	runAddControlDescriptions(t, NewControlString("x", false, ""), "Control Type ()", "Control Value")
+	runAddControlDescriptions(t, NewControlString("x", false, ""), "Control Type ()")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {


### PR DESCRIPTION
Hi, this is PR for cases, if Control doesn't require value, for example
```
	control := ldap.NewControlString("1.3.6.1.4.1.4203.666.5.12", false, "")
	controls := []ldap.Control{}
	controls = append(controls, control)
```
**1.3.6.1.4.1.4203.666.5.12** is for RelaxControl, but if I didn't use this check, ldap server will throw error
```
LDAP Result Code 2 "Protocol Error": relax control value not absent
```

I've checked few libs in Python, C#, Java, they omit values for some controls which do not require values.

Thanks

#212