### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-ldap/ldap
+module github.com/go-ldap/ldap/v3
 
 require gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d


### PR DESCRIPTION
I believe that this (plus a new tag) is what is necessary for native go modules support -- right now go modules complains that the version tag is >= v2 but the module doesn't claim to be a version >= v2.

Fixes #240, I think.