### PR TITLE
Fix printing packets references to use Debug instead of Ber

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -278,7 +278,7 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 			l.Close()
 			return err
 		}
-		ber.PrintPacket(packet)
+		l.Debug.PrintPacket(packet)
 	}
 
 	if err := GetLDAPError(packet); err == nil {
@@ -451,7 +451,7 @@ func (l *Conn) processMessages() {
 					msgCtx.sendResponse(&PacketResponse{message.Packet, nil})
 				} else {
 					log.Printf("Received unexpected message %d, %v", message.MessageID, l.IsClosing())
-					ber.PrintPacket(message.Packet)
+					l.Debug.PrintPacket(message.Packet)
 				}
 			case MessageTimeout:
 				// Handle the timeout by closing the channel

--- a/request.go
+++ b/request.go
@@ -29,7 +29,7 @@ func (l *Conn) doRequest(req request) (*messageContext, error) {
 	}
 
 	if l.Debug {
-		ber.PrintPacket(packet)
+		l.Debug.PrintPacket(packet)
 	}
 
 	msgCtx, err := l.sendMessage(packet)
@@ -60,7 +60,7 @@ func (l *Conn) readPacket(msgCtx *messageContext) (*ber.Packet, error) {
 		if err = addLDAPDescriptions(packet); err != nil {
 			return nil, err
 		}
-		ber.PrintPacket(packet)
+		l.Debug.PrintPacket(packet)
 	}
 	return packet, nil
 }

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -278,7 +278,7 @@ func (l *Conn) StartTLS(config *tls.Config) error {
 			l.Close()
 			return err
 		}
-		ber.PrintPacket(packet)
+		l.Debug.PrintPacket(packet)
 	}
 
 	if err := GetLDAPError(packet); err == nil {
@@ -451,7 +451,7 @@ func (l *Conn) processMessages() {
 					msgCtx.sendResponse(&PacketResponse{message.Packet, nil})
 				} else {
 					log.Printf("Received unexpected message %d, %v", message.MessageID, l.IsClosing())
-					ber.PrintPacket(message.Packet)
+					l.Debug.PrintPacket(message.Packet)
 				}
 			case MessageTimeout:
 				// Handle the timeout by closing the channel

--- a/v3/request.go
+++ b/v3/request.go
@@ -29,7 +29,7 @@ func (l *Conn) doRequest(req request) (*messageContext, error) {
 	}
 
 	if l.Debug {
-		ber.PrintPacket(packet)
+		l.Debug.PrintPacket(packet)
 	}
 
 	msgCtx, err := l.sendMessage(packet)
@@ -60,7 +60,7 @@ func (l *Conn) readPacket(msgCtx *messageContext) (*ber.Packet, error) {
 		if err = addLDAPDescriptions(packet); err != nil {
 			return nil, err
 		}
-		ber.PrintPacket(packet)
+		l.Debug.PrintPacket(packet)
 	}
 	return packet, nil
 }


### PR DESCRIPTION
This is useful for those who fork this repo and change debug's printpacket to use ber.WritePacket instead. that way we only need make a change in one place of code and we don't need change it everywhere else. Makes it more consistent
