### PR TITLE
Dropped test coverage support from legacy go versions: go1.5 go1.6

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,6 @@ jobs:
           '1.9',
           '1.8',
           '1.7',
-          '1.6',
-          '1.5',
         ]
     name: Go ${{ matrix.go }}.x PR Validate (Legacy)
     env:


### PR DESCRIPTION
Fixes #287, unblocks #286 