### PR TITLE
Add an API to specify LDAP Request controls with modifyDN operation

### DIFF
--- a/moddn.go
+++ b/moddn.go
@@ -12,6 +12,8 @@ type ModifyDNRequest struct {
 	NewRDN       string
 	DeleteOldRDN bool
 	NewSuperior  string
+	// Controls hold optional controls to send with the request
+	Controls []Control
 }
 
 // NewModifyDNRequest creates a new request which can be passed to ModifyDN().
@@ -35,21 +37,39 @@ func NewModifyDNRequest(dn string, rdn string, delOld bool, newSup string) *Modi
 	}
 }
 
+// NewModifyDNWithControlsRequest creates a new request which can be passed to ModifyDN()
+// and also allows setting LDAP request controls.
+//
+// Refer NewModifyDNRequest for other parameters
+func NewModifyDNWithControlsRequest(dn string, rdn string, delOld bool,
+	newSup string, controls []Control) *ModifyDNRequest {
+	return &ModifyDNRequest{
+		DN:           dn,
+		NewRDN:       rdn,
+		DeleteOldRDN: delOld,
+		NewSuperior:  newSup,
+		Controls:     controls,
+	}
+}
+
 func (req *ModifyDNRequest) appendTo(envelope *ber.Packet) error {
 	pkt := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationModifyDNRequest, nil, "Modify DN Request")
 	pkt.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, req.DN, "DN"))
 	pkt.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, req.NewRDN, "New RDN"))
 	if req.DeleteOldRDN {
 		buf := []byte{0xff}
-		pkt.AppendChild(ber.NewString(ber.ClassUniversal,ber.TypePrimitive,ber.TagBoolean, string(buf),"Delete old RDN"))
-	}else{
+		pkt.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, string(buf), "Delete old RDN"))
+	} else {
 		pkt.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, req.DeleteOldRDN, "Delete old RDN"))
-	}  
+	}
 	if req.NewSuperior != "" {
 		pkt.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, 0, req.NewSuperior, "New Superior"))
 	}
 
 	envelope.AppendChild(pkt)
+	if len(req.Controls) > 0 {
+		envelope.AppendChild(encodeControls(req.Controls))
+	}
 
 	return nil
 }

--- a/v3/moddn.go
+++ b/v3/moddn.go
@@ -12,6 +12,8 @@ type ModifyDNRequest struct {
 	NewRDN       string
 	DeleteOldRDN bool
 	NewSuperior  string
+	// Controls hold optional controls to send with the request
+	Controls []Control
 }
 
 // NewModifyDNRequest creates a new request which can be passed to ModifyDN().
@@ -35,21 +37,39 @@ func NewModifyDNRequest(dn string, rdn string, delOld bool, newSup string) *Modi
 	}
 }
 
+// NewModifyDNWithControlsRequest creates a new request which can be passed to ModifyDN()
+// and also allows setting LDAP request controls.
+//
+// Refer NewModifyDNRequest for other parameters
+func NewModifyDNWithControlsRequest(dn string, rdn string, delOld bool,
+	newSup string, controls []Control) *ModifyDNRequest {
+	return &ModifyDNRequest{
+		DN:           dn,
+		NewRDN:       rdn,
+		DeleteOldRDN: delOld,
+		NewSuperior:  newSup,
+		Controls:     controls,
+	}
+}
+
 func (req *ModifyDNRequest) appendTo(envelope *ber.Packet) error {
 	pkt := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationModifyDNRequest, nil, "Modify DN Request")
 	pkt.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, req.DN, "DN"))
 	pkt.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, req.NewRDN, "New RDN"))
 	if req.DeleteOldRDN {
 		buf := []byte{0xff}
-		pkt.AppendChild(ber.NewString(ber.ClassUniversal,ber.TypePrimitive,ber.TagBoolean, string(buf),"Delete old RDN"))
-	}else{
+		pkt.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, string(buf), "Delete old RDN"))
+	} else {
 		pkt.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, req.DeleteOldRDN, "Delete old RDN"))
-	}  
+	}
 	if req.NewSuperior != "" {
 		pkt.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, 0, req.NewSuperior, "New Superior"))
 	}
 
 	envelope.AppendChild(pkt)
+	if len(req.Controls) > 0 {
+		envelope.AppendChild(encodeControls(req.Controls))
+	}
 
 	return nil
 }


### PR DESCRIPTION
This allows setting LDAP Request controls with modify DN operation.

Tested against an LDAP server and checked that controls were being sent.
make all - works