### PR TITLE
escape username in auth example

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -193,7 +193,7 @@ func Example_userAuthentication() {
 	searchRequest := NewSearchRequest(
 		"dc=example,dc=com",
 		ScopeWholeSubtree, NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf("(&(objectClass=organizationalPerson)(uid=%s))", username),
+		fmt.Sprintf("(&(objectClass=organizationalPerson)(uid=%s))", EscapeFilter(username)),
 		[]string{"dn"},
 		nil,
 	)

--- a/v3/examples_test.go
+++ b/v3/examples_test.go
@@ -193,7 +193,7 @@ func Example_userAuthentication() {
 	searchRequest := NewSearchRequest(
 		"dc=example,dc=com",
 		ScopeWholeSubtree, NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf("(&(objectClass=organizationalPerson)(uid=%s))", username),
+		fmt.Sprintf("(&(objectClass=organizationalPerson)(uid=%s))", EscapeFilter(username)),
 		[]string{"dn"},
 		nil,
 	)


### PR DESCRIPTION
The authentication example does not escape the username before constructing the search filter. This makes it prone to a LDAP injection attack.