### PR TITLE
return error for ldap action instead of printing them to console

### DIFF
--- a/v3/add.go
+++ b/v3/add.go
@@ -1,8 +1,7 @@
 package ldap
 
 import (
-	"log"
-
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -80,12 +79,8 @@ func (l *Conn) Add(addRequest *AddRequest) error {
 	}
 
 	if packet.Children[1].Tag == ApplicationAddResponse {
-		err := GetLDAPError(packet)
-		if err != nil {
-			return err
-		}
+		return GetLDAPError(packet)
 	} else {
-		log.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("%w: %d", ErrUnexpectedResponse, packet.Children[1].Tag)
 	}
-	return nil
 }

--- a/v3/del.go
+++ b/v3/del.go
@@ -1,8 +1,7 @@
 package ldap
 
 import (
-	"log"
-
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -48,12 +47,8 @@ func (l *Conn) Del(delRequest *DelRequest) error {
 	}
 
 	if packet.Children[1].Tag == ApplicationDelResponse {
-		err := GetLDAPError(packet)
-		if err != nil {
-			return err
-		}
+		return GetLDAPError(packet)
 	} else {
-		log.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("%w: %d", ErrUnexpectedResponse, packet.Children[1].Tag)
 	}
-	return nil
 }

--- a/v3/error.go
+++ b/v3/error.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
@@ -175,6 +176,11 @@ var LDAPResultCodeMap = map[uint16]string{
 	ErrorUnexpectedResponse: "Unexpected Response",
 	ErrorEmptyPassword:      "Empty password not allowed by the client",
 }
+
+var (
+	ErrUnexpectedResponse = errors.New("unexpected response")
+	ErrUnexpectedMessage  = errors.New("unexpected message")
+)
 
 // Error holds LDAP error information
 type Error struct {

--- a/v3/moddn.go
+++ b/v3/moddn.go
@@ -1,8 +1,7 @@
 package ldap
 
 import (
-	"log"
-
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -89,12 +88,8 @@ func (l *Conn) ModifyDN(m *ModifyDNRequest) error {
 	}
 
 	if packet.Children[1].Tag == ApplicationModifyDNResponse {
-		err := GetLDAPError(packet)
-		if err != nil {
-			return err
-		}
+		return GetLDAPError(packet)
 	} else {
-		log.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("%w: %d", ErrUnexpectedResponse, packet.Children[1].Tag)
 	}
-	return nil
 }

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -1,8 +1,7 @@
 package ldap
 
 import (
-	"log"
-
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -121,12 +120,8 @@ func (l *Conn) Modify(modifyRequest *ModifyRequest) error {
 	}
 
 	if packet.Children[1].Tag == ApplicationModifyResponse {
-		err := GetLDAPError(packet)
-		if err != nil {
-			return err
-		}
+		return GetLDAPError(packet)
 	} else {
-		log.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("%w: %d", ErrUnexpectedResponse, packet.Children[1].Tag)
 	}
-	return nil
 }


### PR DESCRIPTION
Hi,

first of all, thank you for this repository, really! While looking for an LDAPv3 implementation in Go for work, I stumpled upon your repository and I'm really grateful you guys took the time to make it :)

While inspecting the codebase I noticed that in some cases, errors are printed directly to `os.Stdout` using `log.Printf`. This is for several reasons not really good:

* The user has no good way to tell if the action has been successfull, since the error is only printed out but not returned
* The app might already use a logging library (like logrus or zap or it's own implementation) instead of `log.Logger`. Logs might be forwarded or piped to a syslog server or to a file, so errors written the default log instance might not appear in the logs aat all.


This change will, instead of printing them to console, return them. This change doesn't change any function signature. If something is wrong or not right, let me know 😊