### PR TITLE
introduce buffering for connection reader

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"bufio"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -532,12 +533,13 @@ func (l *Conn) reader() {
 		}
 	}()
 
+	bufConn := bufio.NewReader(l.conn)
 	for {
 		if cleanstop {
 			l.Debug.Printf("reader clean stopping (without closing the connection)")
 			return
 		}
-		packet, err := ber.ReadPacket(l.conn)
+		packet, err := ber.ReadPacket(bufConn)
 		if err != nil {
 			// A read error is expected here if we are closing the connection...
 			if !l.IsClosing() {

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"bufio"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -532,12 +533,13 @@ func (l *Conn) reader() {
 		}
 	}()
 
+	bufConn := bufio.NewReader(l.conn)
 	for {
 		if cleanstop {
 			l.Debug.Printf("reader clean stopping (without closing the connection)")
 			return
 		}
-		packet, err := ber.ReadPacket(l.conn)
+		packet, err := ber.ReadPacket(bufConn)
 		if err != nil {
 			// A read error is expected here if we are closing the connection...
 			if !l.IsClosing() {


### PR DESCRIPTION
Since asn1-ber ends up reading single bytes, we wrap the network connection into a buffered reader to avoid a syscall for every read.

This is the same thought that guided https://github.com/go-asn1-ber/asn1-ber/pull/31, but as we had to discover in https://github.com/go-asn1-ber/asn1-ber/issues/33, that approach was fundamentally flawed.

This should give us equal speed gains, but without losing any bytes this time.

(I introduced the change in both conn.go and v3/conn.go, though I'm not sure that is correct - feedback welcome)