### PR TITLE
Add support for Active Directory control LDAP_SERVER_EXTENDED_DN_OID 1.2.840.113556.1.4.529

### DIFF
--- a/control.go
+++ b/control.go
@@ -23,15 +23,19 @@ const (
 	ControlTypeMicrosoftNotification = "1.2.840.113556.1.4.528"
 	// ControlTypeMicrosoftShowDeleted - https://msdn.microsoft.com/en-us/library/aa366989(v=vs.85).aspx
 	ControlTypeMicrosoftShowDeleted = "1.2.840.113556.1.4.417"
+
+	// ControlTypeMicrosoftServerExtendedDnOid - LDAP_SERVER_EXTENDED_DN_OID https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3c5e87db-4728-4f29-b164-01dd7d7391ea
+	ControlTypeMicrosoftServerExtendedDnOid = "1.2.840.113556.1.4.529"
 )
 
 // ControlTypeMap maps controls to text descriptions
 var ControlTypeMap = map[string]string{
-	ControlTypePaging:                "Paging",
-	ControlTypeBeheraPasswordPolicy:  "Password Policy - Behera Draft",
-	ControlTypeManageDsaIT:           "Manage DSA IT",
-	ControlTypeMicrosoftNotification: "Change Notification - Microsoft",
-	ControlTypeMicrosoftShowDeleted:  "Show Deleted Objects - Microsoft",
+	ControlTypePaging:                       "Paging",
+	ControlTypeBeheraPasswordPolicy:         "Password Policy - Behera Draft",
+	ControlTypeManageDsaIT:                  "Manage DSA IT",
+	ControlTypeMicrosoftNotification:        "Change Notification - Microsoft",
+	ControlTypeMicrosoftShowDeleted:         "Show Deleted Objects - Microsoft",
+	ControlTypeMicrosoftServerExtendedDnOid: "Show Extended Format DNs (LDAP_SERVER_EXTENDED_DN_OID) - Microsoft",
 }
 
 // Control defines an interface controls provide to encode and describe themselves
@@ -449,6 +453,9 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlMicrosoftNotification(), nil
 	case ControlTypeMicrosoftShowDeleted:
 		return NewControlMicrosoftShowDeleted(), nil
+	case ControlTypeMicrosoftServerExtendedDnOid:
+		c := &ControlMicrosoftServerExtendedDnOid{}
+		return c, nil
 	default:
 		c := new(ControlString)
 		c.ControlType = ControlType

--- a/control_ext.go
+++ b/control_ext.go
@@ -1,0 +1,36 @@
+package ldap
+
+import (
+	ber "github.com/go-asn1-ber/asn1-ber"
+)
+
+// ControlMicrosoftServerExtendedDnOid implements the control LDAP_SERVER_EXTENDED_DN_OID described in
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3c5e87db-4728-4f29-b164-01dd7d7391ea
+type ControlMicrosoftServerExtendedDnOid struct {
+	Critical bool
+	Flag     int
+}
+
+// GetControlType returns the OID
+func (c *ControlMicrosoftServerExtendedDnOid) GetControlType() string {
+	return ControlTypeMicrosoftServerExtendedDnOid
+}
+
+// Encode returns the ber packet representation
+func (c *ControlMicrosoftServerExtendedDnOid) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.GetControlType(), "Control Type ("+ControlTypeMap[ControlTypeMicrosoftServerExtendedDnOid]+")"))
+	packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Critical, "Criticality"))
+
+	p2 := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (Extend DN)")
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "ExtendDNRequestValue")
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, c.Flag, "Flags"))
+	p2.AppendChild(seq)
+	packet.AppendChild(p2)
+
+	return packet
+}
+
+func (c *ControlMicrosoftServerExtendedDnOid) String() string {
+	return ControlTypeMap[ControlTypeMicrosoftServerExtendedDnOid] + " " + c.GetControlType()
+}


### PR DESCRIPTION
Fixes #116

Based on code supplied by @Project0   here: https://github.com/go-ldap/ldap/issues/116#issuecomment-416465844