### PR TITLE
Fix missing IsClosing() from the client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ type Client interface {
 	Start()
 	StartTLS(*tls.Config) error
 	Close()
+	IsClosing() bool
 	SetTimeout(time.Duration)
 
 	Bind(username, password string) error

--- a/v3/client.go
+++ b/v3/client.go
@@ -10,6 +10,7 @@ type Client interface {
 	Start()
 	StartTLS(*tls.Config) error
 	Close()
+	IsClosing() bool
 	SetTimeout(time.Duration)
 
 	Bind(username, password string) error


### PR DESCRIPTION
the `IsClosing()` method is missing from the Client interface, this prevents mocking when using that method.