### PR TITLE
NTLMChallengeBind: avoid panic

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -486,7 +486,7 @@ func (l *Conn) NTLMChallengeBind(ntlmBindRequest *NTLMBindRequest) (*NTLMBindRes
 			child := packet.Children[1].Children[1]
 			ntlmsspChallenge = child.ByteValue
 			// Check to make sure we got the right message. It will always start with NTLMSSP
-			if !bytes.Equal(ntlmsspChallenge[:7], []byte("NTLMSSP")) {
+			if len(ntlmsspChallenge) < 7 || !bytes.Equal(ntlmsspChallenge[:7], []byte("NTLMSSP")) {
 				return result, GetLDAPError(packet)
 			}
 			l.Debug.Printf("%d: found ntlmssp challenge", msgCtx.id)

--- a/v3/bind.go
+++ b/v3/bind.go
@@ -486,7 +486,7 @@ func (l *Conn) NTLMChallengeBind(ntlmBindRequest *NTLMBindRequest) (*NTLMBindRes
 			child := packet.Children[1].Children[1]
 			ntlmsspChallenge = child.ByteValue
 			// Check to make sure we got the right message. It will always start with NTLMSSP
-			if !bytes.Equal(ntlmsspChallenge[:7], []byte("NTLMSSP")) {
+			if len(ntlmsspChallenge) < 7 || !bytes.Equal(ntlmsspChallenge[:7], []byte("NTLMSSP")) {
 				return result, GetLDAPError(packet)
 			}
 			l.Debug.Printf("%d: found ntlmssp challenge", msgCtx.id)


### PR DESCRIPTION
if ntlmsspChallenge is empty or shorter than 7 bytes, the '[:7]' will cause a panic:

```
panic(0xbe1a40, 0xc00013ec60)
	runtime/panic.go:969 +0x1b9
github.com/go-ldap/ldap/v3.(*Conn).NTLMChallengeBind(0xc0002da300, 0xc000382d80, 0x0, 0x0, 0x0)
	github.com/go-ldap/ldap/v3@v3.2.4/bind.go:489 +0xf46
github.com/go-ldap/ldap/v3.(*Conn).NTLMBind(...)
	github.com/go-ldap/ldap/v3@v3.2.4/bind.go:441
```

Thus, avoid the panic by doing a length check.

This was tested against an LDAP server not supporting NTLM authentication. After the change, I get an expected error:
```
LDAP Result Code 7 "Auth Method Not Supported": unknown authentication method
```