### PR TITLE
Change debugger to write packet via log's Writer (#1)

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -25,6 +25,6 @@ func (debug debugging) Printf(format string, args ...interface{}) {
 // PrintPacket dumps a packet.
 func (debug debugging) PrintPacket(packet *ber.Packet) {
 	if debug {
-		ber.PrintPacket(packet)
+		ber.WritePacket(log.Writer(), packet)
 	}
 }

--- a/v3/debug.go
+++ b/v3/debug.go
@@ -25,6 +25,6 @@ func (debug debugging) Printf(format string, args ...interface{}) {
 // PrintPacket dumps a packet.
 func (debug debugging) PrintPacket(packet *ber.Packet) {
 	if debug {
-		ber.PrintPacket(packet)
+		ber.WritePacket(log.Writer(), packet)
 	}
 }


### PR DESCRIPTION
## Issue

Debugger prints debug-level messages via std `log` but prints packets via `os.Stdout`, so it makes impossible to use the `Output` from the global `log`, e.g. `zap` provides [single point of configuration even for the global `log`](https://godoc.org/go.uber.org/zap#RedirectStdLog), so still could be used for libraries logging setup.

## Solution

Pass `log#Writer()` to the `ber` packet writer func.

Partly resolves https://github.com/go-ldap/ldap/issues/164