### PR TITLE
Add Microsoft Control LDAP_SERVER_LINK_TTL_OID

### DIFF
--- a/control.go
+++ b/control.go
@@ -23,6 +23,8 @@ const (
 	ControlTypeMicrosoftNotification = "1.2.840.113556.1.4.528"
 	// ControlTypeMicrosoftShowDeleted - https://msdn.microsoft.com/en-us/library/aa366989(v=vs.85).aspx
 	ControlTypeMicrosoftShowDeleted = "1.2.840.113556.1.4.417"
+	// ControlTypeMicrosoftServerLinkTTL - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
+	ControlTypeMicrosoftServerLinkTTL = "1.2.840.113556.1.4.2309"
 )
 
 // ControlTypeMap maps controls to text descriptions
@@ -32,6 +34,7 @@ var ControlTypeMap = map[string]string{
 	ControlTypeManageDsaIT:           "Manage DSA IT",
 	ControlTypeMicrosoftNotification: "Change Notification - Microsoft",
 	ControlTypeMicrosoftShowDeleted:  "Show Deleted Objects - Microsoft",
+	ControlTypeMicrosoftServerLinkTTL: "Return TTL-DNs for link values with associated expiry times - Microsoft",
 }
 
 // Control defines an interface controls provide to encode and describe themselves
@@ -305,6 +308,35 @@ func NewControlMicrosoftShowDeleted() *ControlMicrosoftShowDeleted {
 	return &ControlMicrosoftShowDeleted{}
 }
 
+// ControlMicrosoftServerLinkTTL implements the control described in https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
+type ControlMicrosoftServerLinkTTL struct{}
+
+// GetControlType returns the OID
+func (c *ControlMicrosoftServerLinkTTL) GetControlType() string {
+	return ControlTypeMicrosoftServerLinkTTL
+}
+
+// Encode returns the ber packet representation
+func (c *ControlMicrosoftServerLinkTTL) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeMicrosoftServerLinkTTL, "Control Type ("+ControlTypeMap[ControlTypeMicrosoftServerLinkTTL]+")"))
+
+	return packet
+}
+
+// String returns a human-readable description
+func (c *ControlMicrosoftServerLinkTTL) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)",
+		ControlTypeMap[ControlTypeMicrosoftServerLinkTTL],
+		ControlTypeMicrosoftServerLinkTTL)
+}
+
+// NewControlMicrosoftServerLinkTTL returns a ControlMicrosoftServerLinkTTL control
+func NewControlMicrosoftServerLinkTTL() *ControlMicrosoftServerLinkTTL {
+	return &ControlMicrosoftServerLinkTTL{}
+}
+
 // FindControl returns the first control of the given type in the list, or nil
 func FindControl(controls []Control, controlType string) Control {
 	for _, c := range controls {
@@ -449,6 +481,8 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlMicrosoftNotification(), nil
 	case ControlTypeMicrosoftShowDeleted:
 		return NewControlMicrosoftShowDeleted(), nil
+	case ControlTypeMicrosoftServerLinkTTL:
+		return NewControlMicrosoftServerLinkTTL(), nil
 	default:
 		c := new(ControlString)
 		c.ControlType = ControlType

--- a/control_test.go
+++ b/control_test.go
@@ -28,6 +28,10 @@ func TestControlMicrosoftShowDeleted(t *testing.T) {
 	runControlTest(t, NewControlMicrosoftShowDeleted())
 }
 
+func TestControlMicrosoftServerLinkTTL(t *testing.T) {
+	runControlTest(t, NewControlMicrosoftServerLinkTTL())
+}
+
 func TestControlString(t *testing.T) {
 	runControlTest(t, NewControlString("x", true, "y"))
 	runControlTest(t, NewControlString("x", true, ""))
@@ -91,6 +95,10 @@ func TestDescribeControlMicrosoftNotification(t *testing.T) {
 
 func TestDescribeControlMicrosoftShowDeleted(t *testing.T) {
 	runAddControlDescriptions(t, NewControlMicrosoftShowDeleted(), "Control Type (Show Deleted Objects - Microsoft)")
+}
+
+func TestDescribeControlMicrosoftServerLinkTTL(t *testing.T) {
+	runAddControlDescriptions(t, NewControlMicrosoftServerLinkTTL(), "Control Type (Return TTL-DNs for link values with associated expiry times - Microsoft)")
 }
 
 func TestDescribeControlString(t *testing.T) {

--- a/v3/control.go
+++ b/v3/control.go
@@ -23,15 +23,18 @@ const (
 	ControlTypeMicrosoftNotification = "1.2.840.113556.1.4.528"
 	// ControlTypeMicrosoftShowDeleted - https://msdn.microsoft.com/en-us/library/aa366989(v=vs.85).aspx
 	ControlTypeMicrosoftShowDeleted = "1.2.840.113556.1.4.417"
+	// ControlTypeMicrosoftServerLinkTTL - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
+	ControlTypeMicrosoftServerLinkTTL = "1.2.840.113556.1.4.2309"
 )
 
 // ControlTypeMap maps controls to text descriptions
 var ControlTypeMap = map[string]string{
-	ControlTypePaging:                "Paging",
-	ControlTypeBeheraPasswordPolicy:  "Password Policy - Behera Draft",
-	ControlTypeManageDsaIT:           "Manage DSA IT",
-	ControlTypeMicrosoftNotification: "Change Notification - Microsoft",
-	ControlTypeMicrosoftShowDeleted:  "Show Deleted Objects - Microsoft",
+	ControlTypePaging:                 "Paging",
+	ControlTypeBeheraPasswordPolicy:   "Password Policy - Behera Draft",
+	ControlTypeManageDsaIT:            "Manage DSA IT",
+	ControlTypeMicrosoftNotification:  "Change Notification - Microsoft",
+	ControlTypeMicrosoftShowDeleted:   "Show Deleted Objects - Microsoft",
+	ControlTypeMicrosoftServerLinkTTL: "Return TTL-DNs for link values with associated expiry times - Microsoft",
 }
 
 // Control defines an interface controls provide to encode and describe themselves
@@ -305,6 +308,35 @@ func NewControlMicrosoftShowDeleted() *ControlMicrosoftShowDeleted {
 	return &ControlMicrosoftShowDeleted{}
 }
 
+// ControlMicrosoftServerLinkTTL implements the control described in https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
+type ControlMicrosoftServerLinkTTL struct{}
+
+// GetControlType returns the OID
+func (c *ControlMicrosoftServerLinkTTL) GetControlType() string {
+	return ControlTypeMicrosoftServerLinkTTL
+}
+
+// Encode returns the ber packet representation
+func (c *ControlMicrosoftServerLinkTTL) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeMicrosoftServerLinkTTL, "Control Type ("+ControlTypeMap[ControlTypeMicrosoftServerLinkTTL]+")"))
+
+	return packet
+}
+
+// String returns a human-readable description
+func (c *ControlMicrosoftServerLinkTTL) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)",
+		ControlTypeMap[ControlTypeMicrosoftServerLinkTTL],
+		ControlTypeMicrosoftServerLinkTTL)
+}
+
+// NewControlMicrosoftServerLinkTTL returns a ControlMicrosoftServerLinkTTL control
+func NewControlMicrosoftServerLinkTTL() *ControlMicrosoftServerLinkTTL {
+	return &ControlMicrosoftServerLinkTTL{}
+}
+
 // FindControl returns the first control of the given type in the list, or nil
 func FindControl(controls []Control, controlType string) Control {
 	for _, c := range controls {
@@ -449,6 +481,8 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlMicrosoftNotification(), nil
 	case ControlTypeMicrosoftShowDeleted:
 		return NewControlMicrosoftShowDeleted(), nil
+	case ControlTypeMicrosoftServerLinkTTL:
+		return NewControlMicrosoftServerLinkTTL(), nil
 	default:
 		c := new(ControlString)
 		c.ControlType = ControlType

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -28,6 +28,10 @@ func TestControlMicrosoftShowDeleted(t *testing.T) {
 	runControlTest(t, NewControlMicrosoftShowDeleted())
 }
 
+func TestControlMicrosoftServerLinkTTL(t *testing.T) {
+	runControlTest(t, NewControlMicrosoftServerLinkTTL())
+}
+
 func TestControlString(t *testing.T) {
 	runControlTest(t, NewControlString("x", true, "y"))
 	runControlTest(t, NewControlString("x", true, ""))
@@ -91,6 +95,10 @@ func TestDescribeControlMicrosoftNotification(t *testing.T) {
 
 func TestDescribeControlMicrosoftShowDeleted(t *testing.T) {
 	runAddControlDescriptions(t, NewControlMicrosoftShowDeleted(), "Control Type (Show Deleted Objects - Microsoft)")
+}
+
+func TestDescribeControlMicrosoftServerLinkTTL(t *testing.T) {
+	runAddControlDescriptions(t, NewControlMicrosoftServerLinkTTL(), "Control Type (Return TTL-DNs for link values with associated expiry times - Microsoft)")
 }
 
 func TestDescribeControlString(t *testing.T) {


### PR DESCRIPTION
This PR adds the Microsoft control LDAP_SERVER_LINK_TTL_OID to the LDAP v3 suite. 

The purpose of this is to view TTLs of group memberships with associated expiry times.

More information on the control can be found at the following link:
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
