### PR TITLE
Add Unbind Request

### DIFF
--- a/unbind.go
+++ b/unbind.go
@@ -2,10 +2,11 @@ package ldap
 
 import (
 	"errors"
+
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
-var ErrConnUnbinded = NewError(ErrorNetwork, errors.New("ldap: connection is closed"))
+var ErrConnUnbound = NewError(ErrorNetwork, errors.New("ldap: connection is closed"))
 
 type unbindRequest struct{}
 
@@ -19,7 +20,7 @@ func (unbindRequest) appendTo(envelope *ber.Packet) error {
 // See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
 func (l *Conn) Unbind() error {
 	if l.IsClosing() {
-		return ErrConnUnbinded
+		return ErrConnUnbound
 	}
 
 	_, err := l.doRequest(unbindRequest{})

--- a/unbind.go
+++ b/unbind.go
@@ -8,7 +8,7 @@ import (
 type unbindRequest struct{}
 
 func (unbindRequest) appendTo(envelope *ber.Packet) error {
-	envelope.AppendChild(ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationUnbindRequest, nil, "Unbind Request"))
+	envelope.AppendChild(ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationUnbindRequest, nil, ApplicationMap[ApplicationUnbindRequest]))
 	return nil
 }
 

--- a/unbind.go
+++ b/unbind.go
@@ -1,9 +1,11 @@
 package ldap
 
 import (
+	"errors"
 	ber "github.com/go-asn1-ber/asn1-ber"
-	"net"
 )
+
+var ErrConnUnbinded = NewError(ErrorNetwork, errors.New("ldap: connection is closed"))
 
 type unbindRequest struct{}
 
@@ -16,8 +18,8 @@ func (unbindRequest) appendTo(envelope *ber.Packet) error {
 // should be thought of as the "quit" operation.
 // See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
 func (l *Conn) Unbind() error {
-	if l.conn == nil || l.IsClosing() {
-		return net.ErrClosed
+	if l.IsClosing() {
+		return ErrConnUnbinded
 	}
 
 	_, err := l.doRequest(unbindRequest{})

--- a/unbind.go
+++ b/unbind.go
@@ -1,0 +1,34 @@
+package ldap
+
+import (
+	ber "github.com/go-asn1-ber/asn1-ber"
+	"net"
+)
+
+type unbindRequest struct{}
+
+func (unbindRequest) appendTo(envelope *ber.Packet) error {
+	envelope.AppendChild(ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationUnbindRequest, nil, "Unbind Request"))
+	return nil
+}
+
+// Unbind will perform an unbind request. The Unbind operation
+// should be thought of as the "quit" operation.
+// See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
+func (l *Conn) Unbind() error {
+	if l.conn == nil || l.IsClosing() {
+		return net.ErrClosed
+	}
+
+	_, err := l.doRequest(unbindRequest{})
+	if err != nil {
+		return err
+	}
+
+	// Sending an unbindRequest will make the connection unusable.
+	// Pending requests will fail with:
+	// LDAP Result Code 200 "Network Error": ldap: response channel closed
+	l.Close()
+
+	return nil
+}

--- a/v3/unbind.go
+++ b/v3/unbind.go
@@ -7,14 +7,12 @@ import (
 
 type unbindRequest struct{}
 
-var _unbindRequest = unbindRequest{}
-
 func (unbindRequest) appendTo(envelope *ber.Packet) error {
-	envelope.AppendChild(ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationUnbindRequest, nil, "Unbind Request"))
+	envelope.AppendChild(ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationUnbindRequest, nil, ApplicationMap[ApplicationUnbindRequest]))
 	return nil
 }
 
-// Unbind will perform a unbind request. The Unbind operation
+// Unbind will perform an unbind request. The Unbind operation
 // should be thought of as the "quit" operation.
 // See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
 func (l *Conn) Unbind() error {
@@ -22,16 +20,12 @@ func (l *Conn) Unbind() error {
 		return net.ErrClosed
 	}
 
-	_, err := l.doRequest(_unbindRequest)
+	_, err := l.doRequest(unbindRequest{})
 	if err != nil {
 		return err
 	}
 
-	// Since an unbindRequest does not send an response, we need
-	// another factor to determine whether the message has been
-	// sent or is still in the channel waiting ...
-	//
-	// Sending an unbindRequest will make the connection unusable anyways.
+	// Sending an unbindRequest will make the connection unusable.
 	// Pending requests will fail with:
 	// LDAP Result Code 200 "Network Error": ldap: response channel closed
 	l.Close()

--- a/v3/unbind.go
+++ b/v3/unbind.go
@@ -2,10 +2,11 @@ package ldap
 
 import (
 	"errors"
+
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
-var ErrConnUnbinded = NewError(ErrorNetwork, errors.New("ldap: connection is closed"))
+var ErrConnUnbound = NewError(ErrorNetwork, errors.New("ldap: connection is closed"))
 
 type unbindRequest struct{}
 
@@ -19,7 +20,7 @@ func (unbindRequest) appendTo(envelope *ber.Packet) error {
 // See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
 func (l *Conn) Unbind() error {
 	if l.IsClosing() {
-		return ErrConnUnbinded
+		return ErrConnUnbound
 	}
 
 	_, err := l.doRequest(unbindRequest{})

--- a/v3/unbind.go
+++ b/v3/unbind.go
@@ -1,9 +1,11 @@
 package ldap
 
 import (
+	"errors"
 	ber "github.com/go-asn1-ber/asn1-ber"
-	"net"
 )
+
+var ErrConnUnbinded = NewError(ErrorNetwork, errors.New("ldap: connection is closed"))
 
 type unbindRequest struct{}
 
@@ -16,8 +18,8 @@ func (unbindRequest) appendTo(envelope *ber.Packet) error {
 // should be thought of as the "quit" operation.
 // See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
 func (l *Conn) Unbind() error {
-	if l.conn == nil || l.IsClosing() {
-		return net.ErrClosed
+	if l.IsClosing() {
+		return ErrConnUnbinded
 	}
 
 	_, err := l.doRequest(unbindRequest{})

--- a/v3/unbind.go
+++ b/v3/unbind.go
@@ -1,0 +1,40 @@
+package ldap
+
+import (
+	ber "github.com/go-asn1-ber/asn1-ber"
+	"net"
+)
+
+type unbindRequest struct{}
+
+var _unbindRequest = unbindRequest{}
+
+func (unbindRequest) appendTo(envelope *ber.Packet) error {
+	envelope.AppendChild(ber.Encode(ber.ClassApplication, ber.TypePrimitive, ApplicationUnbindRequest, nil, "Unbind Request"))
+	return nil
+}
+
+// Unbind will perform a unbind request. The Unbind operation
+// should be thought of as the "quit" operation.
+// See https://datatracker.ietf.org/doc/html/rfc4511#section-4.3
+func (l *Conn) Unbind() error {
+	if l.conn == nil || l.IsClosing() {
+		return net.ErrClosed
+	}
+
+	_, err := l.doRequest(_unbindRequest)
+	if err != nil {
+		return err
+	}
+
+	// Since an unbindRequest does not send an response, we need
+	// another factor to determine whether the message has been
+	// sent or is still in the channel waiting ...
+	//
+	// Sending an unbindRequest will make the connection unusable anyways.
+	// Pending requests will fail with:
+	// LDAP Result Code 200 "Network Error": ldap: response channel closed
+	l.Close()
+
+	return nil
+}


### PR DESCRIPTION
As requested in #324, this PR implements the `unbindRequest` as specificed in [RFC4511](https://datatracker.ietf.org/doc/html/rfc4511#section-4.3). Personally, I don't see why this option shouldn't be added to allow users to gracefully close the connection to the DSA without unwillingly throwing errors on one side.

When the function is called, all outstanding / waiting requests will return an error, since the underlying connection will be closed anyways. 