### PR TITLE
allow using `;` as RDN separator according to rfc2253

### DIFF
--- a/dn.go
+++ b/dn.go
@@ -101,7 +101,7 @@ func ParseDN(str string) (*DN, error) {
 				buffer.WriteString(packet.Data.String())
 				i += len(data) - 1
 			}
-		case char == ',' || char == '+':
+		case char == ',' || char == '+' || char == ';':
 			// We're done with this RDN or value, push it
 			if len(attribute.Type) == 0 {
 				return nil, errors.New("incomplete type, value pair")
@@ -109,7 +109,7 @@ func ParseDN(str string) (*DN, error) {
 			attribute.Value = stringFromBuffer()
 			rdn.Attributes = append(rdn.Attributes, attribute)
 			attribute = new(AttributeTypeAndValue)
-			if char == ',' {
+			if char == ',' || char == ';' {
 				dn.RDNs = append(dn.RDNs, rdn)
 				rdn = new(RelativeDN)
 				rdn.Attributes = make([]*AttributeTypeAndValue, 0)

--- a/dn_test.go
+++ b/dn_test.go
@@ -45,6 +45,17 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			{[]*AttributeTypeAndValue{
 				{"  A  ", "  1  "},
 				{"  B  ", "  2  "}}}}},
+
+		`cn=john.doe;dc=example,dc=net`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "john.doe"}}},
+			{[]*AttributeTypeAndValue{{"dc", "example"}}},
+			{[]*AttributeTypeAndValue{{"dc", "net"}}}}},
+
+		// Escaped `;` should not be treated as RDN
+		`cn=john.doe\;weird name,dc=example,dc=net`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "john.doe;weird name"}}},
+			{[]*AttributeTypeAndValue{{"dc", "example"}}},
+			{[]*AttributeTypeAndValue{{"dc", "net"}}}}},
 	}
 
 	for test, answer := range testcases {
@@ -147,6 +158,8 @@ func TestDNEqual(t *testing.T) {
 			"cn=John  Doe, ou=People, dc=sun.com",
 			false,
 		},
+		// Test parsing of `;` for separating RDNs
+		{"cn=john;dc=example,dc=com", "cn=john,dc=example,dc=com", true}, // missing values matter
 	}
 
 	for i, tc := range testcases {

--- a/v3/dn.go
+++ b/v3/dn.go
@@ -101,7 +101,7 @@ func ParseDN(str string) (*DN, error) {
 				buffer.WriteString(packet.Data.String())
 				i += len(data) - 1
 			}
-		case char == ',' || char == '+':
+		case char == ',' || char == '+' || char == ';':
 			// We're done with this RDN or value, push it
 			if len(attribute.Type) == 0 {
 				return nil, errors.New("incomplete type, value pair")
@@ -109,7 +109,7 @@ func ParseDN(str string) (*DN, error) {
 			attribute.Value = stringFromBuffer()
 			rdn.Attributes = append(rdn.Attributes, attribute)
 			attribute = new(AttributeTypeAndValue)
-			if char == ',' {
+			if char == ',' || char == ';' {
 				dn.RDNs = append(dn.RDNs, rdn)
 				rdn = new(RelativeDN)
 				rdn.Attributes = make([]*AttributeTypeAndValue, 0)

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -45,6 +45,17 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			{[]*AttributeTypeAndValue{
 				{"  A  ", "  1  "},
 				{"  B  ", "  2  "}}}}},
+
+		`cn=john.doe;dc=example,dc=net`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "john.doe"}}},
+			{[]*AttributeTypeAndValue{{"dc", "example"}}},
+			{[]*AttributeTypeAndValue{{"dc", "net"}}}}},
+
+		// Escaped `;` should not be treated as RDN
+		`cn=john.doe\;weird name,dc=example,dc=net`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "john.doe;weird name"}}},
+			{[]*AttributeTypeAndValue{{"dc", "example"}}},
+			{[]*AttributeTypeAndValue{{"dc", "net"}}}}},
 	}
 
 	for test, answer := range testcases {
@@ -147,6 +158,8 @@ func TestDNEqual(t *testing.T) {
 			"cn=John  Doe, ou=People, dc=sun.com",
 			false,
 		},
+		// Test parsing of `;` for separating RDNs
+		{"cn=john;dc=example,dc=com", "cn=john,dc=example,dc=com", true}, // missing values matter
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION
Fixes #351 