### PR TITLE
Update minimum Go version to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-ldap/ldap
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-ldap/ldap/v3
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e


### PR DESCRIPTION
The PR is intended to be complementary to PR #367 and set the minimum Go version to 1.14 in the go.mod files.