### PR TITLE
Add missing `Client` interface methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,11 +12,14 @@ type Client interface {
 	Close()
 	IsClosing() bool
 	SetTimeout(time.Duration)
+	TLSConnectionState() (tls.ConnectionState, bool)
 
 	Bind(username, password string) error
 	UnauthenticatedBind(username string) error
 	SimpleBind(*SimpleBindRequest) (*SimpleBindResult, error)
 	ExternalBind() error
+	NTLMUnauthenticatedBind(domain, username string) error
+	Unbind() error
 
 	Add(*AddRequest) error
 	Del(*DelRequest) error

--- a/v3/client.go
+++ b/v3/client.go
@@ -12,11 +12,14 @@ type Client interface {
 	Close()
 	IsClosing() bool
 	SetTimeout(time.Duration)
+	TLSConnectionState() (tls.ConnectionState, bool)
 
 	Bind(username, password string) error
 	UnauthenticatedBind(username string) error
 	SimpleBind(*SimpleBindRequest) (*SimpleBindResult, error)
 	ExternalBind() error
+	NTLMUnauthenticatedBind(domain, username string) error
+	Unbind() error
 
 	Add(*AddRequest) error
 	Del(*DelRequest) error


### PR DESCRIPTION
It seems the `Client` interface hasn't been updated in a while. Some methods which have been added to `Conn` were missing  😅