### PR TITLE
feat: return referrals for modify operation

### DIFF
--- a/modify.go
+++ b/modify.go
@@ -161,18 +161,7 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	case ApplicationModifyResponse:
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
-				for _, child := range packet.Children[1].Children {
-					if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
-						referral, ok := child.Children[0].Value.(string)
-						if ok {
-							result.Referral = referral
-
-							break
-						}
-					}
-				}
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/modify.go
+++ b/modify.go
@@ -159,9 +159,12 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 
 	switch packet.Children[1].Tag {
 	case ApplicationModifyResponse:
-		err := GetLDAPError(packet)
-		if err != nil {
-			result.Referral = getReferral(err, packet)
+		if err = GetLDAPError(packet); err != nil {
+			if referral, referralErr := getReferral(err, packet); referralErr != nil {
+				return result, err
+			} else {
+				result.Referral = referral
+			}
 
 			return result, err
 		}

--- a/modify.go
+++ b/modify.go
@@ -161,10 +161,15 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	case ApplicationModifyResponse:
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) {
+			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
 				for _, child := range packet.Children[1].Children {
-					if child.Tag == 3 {
-						result.Referral = child.Children[0].Value.(string)
+					if child.Tag == 3 && len(child.Children) >= 1 {
+						referral, ok := child.Children[0].Value.(string)
+						if !ok {
+							continue
+						}
+
+						result.Referral = referral
 					}
 				}
 			}

--- a/modify.go
+++ b/modify.go
@@ -161,7 +161,7 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	case ApplicationModifyResponse:
 		if err = GetLDAPError(packet); err != nil {
 			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, err
+				return result, referralErr
 			} else {
 				result.Referral = referral
 			}

--- a/modify.go
+++ b/modify.go
@@ -163,13 +163,13 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 		if err != nil {
 			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
 				for _, child := range packet.Children[1].Children {
-					if child.Tag == 3 && len(child.Children) >= 1 {
+					if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
 						referral, ok := child.Children[0].Value.(string)
-						if !ok {
-							continue
-						}
+						if ok {
+							result.Referral = referral
 
-						result.Referral = referral
+							break
+						}
 					}
 				}
 			}

--- a/passwdmodify.go
+++ b/passwdmodify.go
@@ -97,18 +97,7 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
-				for _, child := range packet.Children[1].Children {
-					if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
-						referral, ok := child.Children[0].Value.(string)
-						if ok {
-							result.Referral = referral
-
-							break
-						}
-					}
-				}
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/passwdmodify.go
+++ b/passwdmodify.go
@@ -95,9 +95,12 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	result := &PasswordModifyResult{}
 
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
-		err := GetLDAPError(packet)
-		if err != nil {
-			result.Referral = getReferral(err, packet)
+		if err = GetLDAPError(packet); err != nil {
+			if referral, referralErr := getReferral(err, packet); referralErr != nil {
+				return result, err
+			} else {
+				result.Referral = referral
+			}
 
 			return result, err
 		}

--- a/passwdmodify.go
+++ b/passwdmodify.go
@@ -97,7 +97,7 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		if err = GetLDAPError(packet); err != nil {
 			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, err
+				return result, referralErr
 			} else {
 				result.Referral = referral
 			}

--- a/passwdmodify.go
+++ b/passwdmodify.go
@@ -97,13 +97,19 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) {
+			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
 				for _, child := range packet.Children[1].Children {
-					if child.Tag == 3 {
-						result.Referral = child.Children[0].Value.(string)
+					if child.Tag == 3 && len(child.Children) >= 1 {
+						referral, ok := child.Children[0].Value.(string)
+						if !ok {
+							continue
+						}
+
+						result.Referral = referral
 					}
 				}
 			}
+
 			return result, err
 		}
 	} else {

--- a/request.go
+++ b/request.go
@@ -69,3 +69,21 @@ func (l *Conn) readPacket(msgCtx *messageContext) (*ber.Packet, error) {
 	}
 	return packet, nil
 }
+
+func getReferral(err error, packet *ber.Packet) (referral string) {
+	var ok bool
+
+	if !IsErrorWithCode(err, LDAPResultReferral) || len(packet.Children) < 2 {
+		return ""
+	}
+
+	for _, child := range packet.Children[1].Children {
+		if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
+			if referral, ok = child.Children[0].Value.(string); ok {
+				return referral
+			}
+		}
+	}
+
+	return ""
+}

--- a/request.go
+++ b/request.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"errors"
+	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -70,20 +71,28 @@ func (l *Conn) readPacket(msgCtx *messageContext) (*ber.Packet, error) {
 	return packet, nil
 }
 
-func getReferral(err error, packet *ber.Packet) (referral string) {
-	var ok bool
-
-	if !IsErrorWithCode(err, LDAPResultReferral) || len(packet.Children) < 2 {
-		return ""
+func getReferral(err error, packet *ber.Packet) (referral string, e error) {
+	if !IsErrorWithCode(err, LDAPResultReferral) {
+		return "", nil
 	}
+
+	if len(packet.Children) < 2 {
+		return "", fmt.Errorf("ldap: returned error indicates the packet contains a referral but it doesn't have sufficient child nodes: %w", err)
+	}
+
+	if packet.Children[1].Tag != ber.TagObjectDescriptor {
+		return "", fmt.Errorf("ldap: returned error indicates the packet contains a referral but the relevant child node isn't an object descriptor: %w", err)
+	}
+
+	var ok bool
 
 	for _, child := range packet.Children[1].Children {
 		if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
 			if referral, ok = child.Children[0].Value.(string); ok {
-				return referral
+				return referral, nil
 			}
 		}
 	}
 
-	return ""
+	return "", fmt.Errorf("ldap: returned error indicates the packet contains a referral but the referral couldn't be decoded: %w", err)
 }

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -161,18 +161,7 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	case ApplicationModifyResponse:
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
-				for _, child := range packet.Children[1].Children {
-					if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
-						referral, ok := child.Children[0].Value.(string)
-						if ok {
-							result.Referral = referral
-
-							break
-						}
-					}
-				}
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -159,9 +159,12 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 
 	switch packet.Children[1].Tag {
 	case ApplicationModifyResponse:
-		err := GetLDAPError(packet)
-		if err != nil {
-			result.Referral = getReferral(err, packet)
+		if err = GetLDAPError(packet); err != nil {
+			if referral, referralErr := getReferral(err, packet); referralErr != nil {
+				return result, err
+			} else {
+				result.Referral = referral
+			}
 
 			return result, err
 		}

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -161,10 +161,15 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	case ApplicationModifyResponse:
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) {
+			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
 				for _, child := range packet.Children[1].Children {
-					if child.Tag == 3 {
-						result.Referral = child.Children[0].Value.(string)
+					if child.Tag == 3 && len(child.Children) >= 1 {
+						referral, ok := child.Children[0].Value.(string)
+						if !ok {
+							continue
+						}
+
+						result.Referral = referral
 					}
 				}
 			}

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -161,7 +161,7 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	case ApplicationModifyResponse:
 		if err = GetLDAPError(packet); err != nil {
 			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, err
+				return result, referralErr
 			} else {
 				result.Referral = referral
 			}

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -163,13 +163,13 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 		if err != nil {
 			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
 				for _, child := range packet.Children[1].Children {
-					if child.Tag == 3 && len(child.Children) >= 1 {
+					if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
 						referral, ok := child.Children[0].Value.(string)
-						if !ok {
-							continue
-						}
+						if ok {
+							result.Referral = referral
 
-						result.Referral = referral
+							break
+						}
 					}
 				}
 			}

--- a/v3/passwdmodify.go
+++ b/v3/passwdmodify.go
@@ -97,18 +97,7 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
-				for _, child := range packet.Children[1].Children {
-					if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
-						referral, ok := child.Children[0].Value.(string)
-						if ok {
-							result.Referral = referral
-
-							break
-						}
-					}
-				}
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/v3/passwdmodify.go
+++ b/v3/passwdmodify.go
@@ -95,9 +95,12 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	result := &PasswordModifyResult{}
 
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
-		err := GetLDAPError(packet)
-		if err != nil {
-			result.Referral = getReferral(err, packet)
+		if err = GetLDAPError(packet); err != nil {
+			if referral, referralErr := getReferral(err, packet); referralErr != nil {
+				return result, err
+			} else {
+				result.Referral = referral
+			}
 
 			return result, err
 		}

--- a/v3/passwdmodify.go
+++ b/v3/passwdmodify.go
@@ -97,7 +97,7 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		if err = GetLDAPError(packet); err != nil {
 			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, err
+				return result, referralErr
 			} else {
 				result.Referral = referral
 			}

--- a/v3/passwdmodify.go
+++ b/v3/passwdmodify.go
@@ -97,13 +97,19 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		err := GetLDAPError(packet)
 		if err != nil {
-			if IsErrorWithCode(err, LDAPResultReferral) {
+			if IsErrorWithCode(err, LDAPResultReferral) && len(packet.Children) >= 2 {
 				for _, child := range packet.Children[1].Children {
-					if child.Tag == 3 {
-						result.Referral = child.Children[0].Value.(string)
+					if child.Tag == 3 && len(child.Children) >= 1 {
+						referral, ok := child.Children[0].Value.(string)
+						if !ok {
+							continue
+						}
+
+						result.Referral = referral
 					}
 				}
 			}
+
 			return result, err
 		}
 	} else {

--- a/v3/request.go
+++ b/v3/request.go
@@ -69,3 +69,21 @@ func (l *Conn) readPacket(msgCtx *messageContext) (*ber.Packet, error) {
 	}
 	return packet, nil
 }
+
+func getReferral(err error, packet *ber.Packet) (referral string) {
+	var ok bool
+
+	if !IsErrorWithCode(err, LDAPResultReferral) || len(packet.Children) < 2 {
+		return ""
+	}
+
+	for _, child := range packet.Children[1].Children {
+		if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
+			if referral, ok = child.Children[0].Value.(string); ok {
+				return referral
+			}
+		}
+	}
+
+	return ""
+}

--- a/v3/request.go
+++ b/v3/request.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"errors"
+	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -70,20 +71,28 @@ func (l *Conn) readPacket(msgCtx *messageContext) (*ber.Packet, error) {
 	return packet, nil
 }
 
-func getReferral(err error, packet *ber.Packet) (referral string) {
-	var ok bool
-
-	if !IsErrorWithCode(err, LDAPResultReferral) || len(packet.Children) < 2 {
-		return ""
+func getReferral(err error, packet *ber.Packet) (referral string, e error) {
+	if !IsErrorWithCode(err, LDAPResultReferral) {
+		return "", nil
 	}
+
+	if len(packet.Children) < 2 {
+		return "", fmt.Errorf("ldap: returned error indicates the packet contains a referral but it doesn't have sufficient child nodes: %w", err)
+	}
+
+	if packet.Children[1].Tag != ber.TagObjectDescriptor {
+		return "", fmt.Errorf("ldap: returned error indicates the packet contains a referral but the relevant child node isn't an object descriptor: %w", err)
+	}
+
+	var ok bool
 
 	for _, child := range packet.Children[1].Children {
 		if child.Tag == ber.TagBitString && len(child.Children) >= 1 {
 			if referral, ok = child.Children[0].Value.(string); ok {
-				return referral
+				return referral, nil
 			}
 		}
 	}
 
-	return ""
+	return "", fmt.Errorf("ldap: returned error indicates the packet contains a referral but the referral couldn't be decoded: %w", err)
 }


### PR DESCRIPTION
This implements returning the referral for the modify operation. Tested against a Microsoft Active Directory Read-only Domain Controller. 

This also adds anti-panic guards in edge cases where the packet is malformed. This could be refactored to return an error or be removed entirely depending on what is considered to be desired/appropriate by maintainers. I also utilized the ASN.1 BER consts to check tag types in relevant code sections as I think this is more readable, and factorized the code into a single method rather than duplicating it.

Decisions:
- [x] We could export a method which takes the error and returns the referral if applicable. Would be useful in any instance where there may be referrals which have not been accounted for. This may also be the appropriate way to handle all instances, but I think that's a breaking change and consistency is also important for a cohesive API.
- [x] Do we want to outright return errors in edge cases where the decoded BER packet has an unexpected structure, or do we want to just utilize the safeguards? Or do we want to remove the safeguards entirely since the chance of this happening is _**probably**_ negligible? Also noteworthy is it's not specifically an LDAP error so that may stray from the API.