### PR TITLE
added int and []byte type to entry unmarshal

### DIFF
--- a/search.go
+++ b/search.go
@@ -185,9 +185,9 @@ func readTag(f reflect.StructField) (string, bool) {
 // Unmarshal parses the Entry in the value pointed to by i
 //
 // Currently, this methods only supports struct fields of type
-// string, []string, int or []byte. Other field types will not be regarded.
-// If the field type is a string or int but multiple attribute values
-// are returned, the first value will be used to fill the field.
+// string, []string, int, int64 or []byte. Other field types will not be
+// regarded. If the field type is a string or int but multiple attribute
+// values are returned, the first value will be used to fill the field.
 //
 // Example:
 //	type UserEntry struct {
@@ -207,6 +207,9 @@ func readTag(f reflect.StructField) (string, bool) {
 //		// ID is an integer value, it will fail unmarshaling when the given
 //		// attribute value cannot be parsed into an integer.
 //		ID int `ldap:"id"`
+//
+//		// LongID is similar to ID but uses an int64 instead.
+//		LongID int64 `ldap:"longId"`
 //
 //		// Data is similar to MemberOf a slice containing all attribute
 //		// values.
@@ -265,12 +268,12 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 			fv.SetString(values[0])
 		case []byte:
 			fv.SetBytes([]byte(values[0]))
-		case int:
-			intVal, err := strconv.ParseInt(values[0], 10, 32)
+		case int, int64:
+			intVal, err := strconv.ParseInt(values[0], 10, 64)
 			if err != nil {
 				return fmt.Errorf("ldap: could not parse value '%s' into int field", values[0])
 			}
-			fv.SetInt(int64(intVal))
+			fv.SetInt(intVal)
 		default:
 			return fmt.Errorf("ldap: expected field to be of type string, []string, int or []byte, got %v", ft.Type)
 		}

--- a/search.go
+++ b/search.go
@@ -275,7 +275,7 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 			}
 			fv.SetInt(intVal)
 		default:
-			return fmt.Errorf("ldap: expected field to be of type string, []string, int or []byte, got %v", ft.Type)
+			return fmt.Errorf("ldap: expected field to be of type string, []string, int, int64 or []byte, got %v", ft.Type)
 		}
 	}
 	return

--- a/search_test.go
+++ b/search_test.go
@@ -86,6 +86,20 @@ func TestEntry_Unmarshal(t *testing.T) {
 					Values:     []string{"mario@go-ldap.com"},
 					ByteValues: nil,
 				},
+				// Tests int value.
+				{
+					Name:       "id",
+					Values:     []string{"2147483647"},
+					ByteValues: nil,
+				},
+				// Tests []byte value.
+				{
+					Name:   "data",
+					Values: []string{"data"},
+					ByteValues: [][]byte{
+						[]byte("data"),
+					},
+				},
 			},
 		}
 
@@ -93,12 +107,16 @@ func TestEntry_Unmarshal(t *testing.T) {
 			Dn   string `ldap:"dn"`
 			Cn   string `ldap:"cn"`
 			Mail string `ldap:"mail"`
+			ID   int    `ldap:"id"`
+			Data []byte `ldap:"data"`
 		}
 
 		expect := &User{
 			Dn:   "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
 			Cn:   "mario",
 			Mail: "mario@go-ldap.com",
+			ID:   2147483647,
+			Data: []byte("data"),
 		}
 		result := &User{}
 		err := entry.Unmarshal(result)

--- a/search_test.go
+++ b/search_test.go
@@ -92,6 +92,12 @@ func TestEntry_Unmarshal(t *testing.T) {
 					Values:     []string{"2147483647"},
 					ByteValues: nil,
 				},
+				// Tests int64 value.
+				{
+					Name:       "longId",
+					Values:     []string{"9223372036854775807"},
+					ByteValues: nil,
+				},
 				// Tests []byte value.
 				{
 					Name:   "data",
@@ -104,19 +110,21 @@ func TestEntry_Unmarshal(t *testing.T) {
 		}
 
 		type User struct {
-			Dn   string `ldap:"dn"`
-			Cn   string `ldap:"cn"`
-			Mail string `ldap:"mail"`
-			ID   int    `ldap:"id"`
-			Data []byte `ldap:"data"`
+			Dn     string `ldap:"dn"`
+			Cn     string `ldap:"cn"`
+			Mail   string `ldap:"mail"`
+			ID     int    `ldap:"id"`
+			LongID int64  `ldap:"longId"`
+			Data   []byte `ldap:"data"`
 		}
 
 		expect := &User{
-			Dn:   "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
-			Cn:   "mario",
-			Mail: "mario@go-ldap.com",
-			ID:   2147483647,
-			Data: []byte("data"),
+			Dn:     "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
+			Cn:     "mario",
+			Mail:   "mario@go-ldap.com",
+			ID:     2147483647,
+			LongID: 9223372036854775807,
+			Data:   []byte("data"),
 		}
 		result := &User{}
 		err := entry.Unmarshal(result)

--- a/v3/search.go
+++ b/v3/search.go
@@ -185,9 +185,9 @@ func readTag(f reflect.StructField) (string, bool) {
 // Unmarshal parses the Entry in the value pointed to by i
 //
 // Currently, this methods only supports struct fields of type
-// string, []string, int or []byte. Other field types will not be regarded.
-// If the field type is a string or int but multiple attribute values
-// are returned, the first value will be used to fill the field.
+// string, []string, int, int64 or []byte. Other field types will not be
+// regarded. If the field type is a string or int but multiple attribute
+// values are returned, the first value will be used to fill the field.
 //
 // Example:
 //	type UserEntry struct {
@@ -207,6 +207,9 @@ func readTag(f reflect.StructField) (string, bool) {
 //		// ID is an integer value, it will fail unmarshaling when the given
 //		// attribute value cannot be parsed into an integer.
 //		ID int `ldap:"id"`
+//
+//		// LongID is similar to ID but uses an int64 instead.
+//		LongID int64 `ldap:"longId"`
 //
 //		// Data is similar to MemberOf a slice containing all attribute
 //		// values.
@@ -265,12 +268,12 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 			fv.SetString(values[0])
 		case []byte:
 			fv.SetBytes([]byte(values[0]))
-		case int:
-			intVal, err := strconv.ParseInt(values[0], 10, 32)
+		case int, int64:
+			intVal, err := strconv.ParseInt(values[0], 10, 64)
 			if err != nil {
 				return fmt.Errorf("ldap: could not parse value '%s' into int field", values[0])
 			}
-			fv.SetInt(int64(intVal))
+			fv.SetInt(intVal)
 		default:
 			return fmt.Errorf("ldap: expected field to be of type string, []string, int or []byte, got %v", ft.Type)
 		}

--- a/v3/search.go
+++ b/v3/search.go
@@ -275,7 +275,7 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 			}
 			fv.SetInt(intVal)
 		default:
-			return fmt.Errorf("ldap: expected field to be of type string, []string, int or []byte, got %v", ft.Type)
+			return fmt.Errorf("ldap: expected field to be of type string, []string, int, int64 or []byte, got %v", ft.Type)
 		}
 	}
 	return

--- a/v3/search_test.go
+++ b/v3/search_test.go
@@ -86,6 +86,20 @@ func TestEntry_Unmarshal(t *testing.T) {
 					Values:     []string{"mario@go-ldap.com"},
 					ByteValues: nil,
 				},
+				// Tests int value.
+				{
+					Name:       "id",
+					Values:     []string{"2147483647"},
+					ByteValues: nil,
+				},
+				// Tests []byte value.
+				{
+					Name:   "data",
+					Values: []string{"data"},
+					ByteValues: [][]byte{
+						[]byte("data"),
+					},
+				},
 			},
 		}
 
@@ -93,12 +107,16 @@ func TestEntry_Unmarshal(t *testing.T) {
 			Dn   string `ldap:"dn"`
 			Cn   string `ldap:"cn"`
 			Mail string `ldap:"mail"`
+			ID   int    `ldap:"id"`
+			Data []byte `ldap:"data"`
 		}
 
 		expect := &User{
 			Dn:   "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
 			Cn:   "mario",
 			Mail: "mario@go-ldap.com",
+			ID:   2147483647,
+			Data: []byte("data"),
 		}
 		result := &User{}
 		err := entry.Unmarshal(result)

--- a/v3/search_test.go
+++ b/v3/search_test.go
@@ -92,6 +92,12 @@ func TestEntry_Unmarshal(t *testing.T) {
 					Values:     []string{"2147483647"},
 					ByteValues: nil,
 				},
+				// Tests int64 value.
+				{
+					Name:       "longId",
+					Values:     []string{"9223372036854775807"},
+					ByteValues: nil,
+				},
 				// Tests []byte value.
 				{
 					Name:   "data",
@@ -104,19 +110,21 @@ func TestEntry_Unmarshal(t *testing.T) {
 		}
 
 		type User struct {
-			Dn   string `ldap:"dn"`
-			Cn   string `ldap:"cn"`
-			Mail string `ldap:"mail"`
-			ID   int    `ldap:"id"`
-			Data []byte `ldap:"data"`
+			Dn     string `ldap:"dn"`
+			Cn     string `ldap:"cn"`
+			Mail   string `ldap:"mail"`
+			ID     int    `ldap:"id"`
+			LongID int64  `ldap:"longId"`
+			Data   []byte `ldap:"data"`
 		}
 
 		expect := &User{
-			Dn:   "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
-			Cn:   "mario",
-			Mail: "mario@go-ldap.com",
-			ID:   2147483647,
-			Data: []byte("data"),
+			Dn:     "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
+			Cn:     "mario",
+			Mail:   "mario@go-ldap.com",
+			ID:     2147483647,
+			LongID: 9223372036854775807,
+			Data:   []byte("data"),
 		}
 		result := &User{}
 		err := entry.Unmarshal(result)


### PR DESCRIPTION
Based on the ground work of #304 this PR adds two additional supported variable types: int and []byte.