### PR TITLE
Add function to escape distinguished names

### DIFF
--- a/ldap.go
+++ b/ldap.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -344,4 +345,44 @@ func EscapeFilter(filter string) string {
 		}
 	}
 	return string(buf)
+}
+
+// EscapeDN escapes distinguished names as described in RFC4514. Characters in the
+// set `"+,;<>\` are escaped by prepending a backslash, which is also done for trailing
+// spaces or a leading `#`. Null bytes are replaced with `\00`.
+func EscapeDN(dn string) string {
+	if dn == "" {
+		return ""
+	}
+
+	builder := strings.Builder{}
+
+	for i, r := range dn {
+		// Escape leading and trailing spaces
+		if (i == 0 || i == len(dn)-1) && r == ' ' {
+			builder.WriteRune('\\')
+			builder.WriteRune(r)
+			continue
+		}
+
+		// Escape leading '#'
+		if i == 0 && r == '#' {
+			builder.WriteRune('\\')
+			builder.WriteRune(r)
+			continue
+		}
+
+		// Escape characters as defined in RFC4514
+		switch r {
+		case '"', '+', ',', ';', '<', '>', '\\':
+			builder.WriteRune('\\')
+			builder.WriteRune(r)
+		case '\x00': // Null byte may not be escaped by a leading backslash
+			builder.WriteString("\\00")
+		default:
+			builder.WriteRune(r)
+		}
+	}
+
+	return builder.String()
 }

--- a/ldap_test.go
+++ b/ldap_test.go
@@ -334,6 +334,7 @@ func TestEscapeDN(t *testing.T) {
 		{name: "whitespaces", dn: "  test user  ", want: "\\  test user \\ "},
 		{name: "nullByte", dn: "\u0000te\x00st\x00user" + string(rune(0)), want: "\\00te\\00st\\00user\\00"},
 		{name: "variousCharacters", dn: "test\"+,;<>\\-_user", want: "test\\\"\\+\\,\\;\\<\\>\\\\-_user"},
+		{name: "multiByteRunes", dn: "test\u0391user ", want: "test\u0391user\\ "},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ldap_test.go
+++ b/ldap_test.go
@@ -320,3 +320,26 @@ func Test_addControlDescriptions(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeDN(t *testing.T) {
+	tests := []struct {
+		name string
+		dn   string
+		want string
+	}{
+		{name: "emptyString", dn: "", want: ""},
+		{name: "comma", dn: "test,user", want: "test\\,user"},
+		{name: "numberSign", dn: "#test#user#", want: "\\#test#user#"},
+		{name: "backslash", dn: "\\test\\user\\", want: "\\\\test\\\\user\\\\"},
+		{name: "whitespaces", dn: "  test user  ", want: "\\  test user \\ "},
+		{name: "nullByte", dn: "\u0000te\x00st\x00user" + string(rune(0)), want: "\\00te\\00st\\00user\\00"},
+		{name: "variousCharacters", dn: "test\"+,;<>\\-_user", want: "test\\\"\\+\\,\\;\\<\\>\\\\-_user"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EscapeDN(tt.dn); got != tt.want {
+				t.Errorf("EscapeDN(%s) = %s, expected %s", tt.dn, got, tt.want)
+			}
+		})
+	}
+}

--- a/v3/ldap.go
+++ b/v3/ldap.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -344,4 +345,44 @@ func EscapeFilter(filter string) string {
 		}
 	}
 	return string(buf)
+}
+
+// EscapeDN escapes distinguished names as described in RFC4514. Characters in the
+// set `"+,;<>\` are escaped by prepending a backslash, which is also done for trailing
+// spaces or a leading `#`. Null bytes are replaced with `\00`.
+func EscapeDN(dn string) string {
+	if dn == "" {
+		return ""
+	}
+
+	builder := strings.Builder{}
+
+	for i, r := range dn {
+		// Escape leading and trailing spaces
+		if (i == 0 || i == len(dn)-1) && r == ' ' {
+			builder.WriteRune('\\')
+			builder.WriteRune(r)
+			continue
+		}
+
+		// Escape leading '#'
+		if i == 0 && r == '#' {
+			builder.WriteRune('\\')
+			builder.WriteRune(r)
+			continue
+		}
+
+		// Escape characters as defined in RFC4514
+		switch r {
+		case '"', '+', ',', ';', '<', '>', '\\':
+			builder.WriteRune('\\')
+			builder.WriteRune(r)
+		case '\x00': // Null byte may not be escaped by a leading backslash
+			builder.WriteString("\\00")
+		default:
+			builder.WriteRune(r)
+		}
+	}
+
+	return builder.String()
 }

--- a/v3/ldap_test.go
+++ b/v3/ldap_test.go
@@ -334,6 +334,7 @@ func TestEscapeDN(t *testing.T) {
 		{name: "whitespaces", dn: "  test user  ", want: "\\  test user \\ "},
 		{name: "nullByte", dn: "\u0000te\x00st\x00user" + string(rune(0)), want: "\\00te\\00st\\00user\\00"},
 		{name: "variousCharacters", dn: "test\"+,;<>\\-_user", want: "test\\\"\\+\\,\\;\\<\\>\\\\-_user"},
+		{name: "multiByteRunes", dn: "test\u0391user ", want: "test\u0391user\\ "},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/v3/ldap_test.go
+++ b/v3/ldap_test.go
@@ -320,3 +320,26 @@ func Test_addControlDescriptions(t *testing.T) {
 		})
 	}
 }
+
+func TestEscapeDN(t *testing.T) {
+	tests := []struct {
+		name string
+		dn   string
+		want string
+	}{
+		{name: "emptyString", dn: "", want: ""},
+		{name: "comma", dn: "test,user", want: "test\\,user"},
+		{name: "numberSign", dn: "#test#user#", want: "\\#test#user#"},
+		{name: "backslash", dn: "\\test\\user\\", want: "\\\\test\\\\user\\\\"},
+		{name: "whitespaces", dn: "  test user  ", want: "\\  test user \\ "},
+		{name: "nullByte", dn: "\u0000te\x00st\x00user" + string(rune(0)), want: "\\00te\\00st\\00user\\00"},
+		{name: "variousCharacters", dn: "test\"+,;<>\\-_user", want: "test\\\"\\+\\,\\;\\<\\>\\\\-_user"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EscapeDN(tt.dn); got != tt.want {
+				t.Errorf("EscapeDN(%s) = %s, expected %s", tt.dn, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a function to escape distinguished names, as described in RFC4514.

The use case is to allow building valid DNs from untrusted input, for example if the group name is user supplied like in the following example:
```
func ModifyGroup(groupName string) {
	groupCN := fmt.Sprintf("cn=%s,ou=groups,dc=example,dc=org", ldap.EscapeDN(groupName))

	ldap.NewModifyRequest(groupCN, nil)
	...
}
```