### PR TITLE
Add CLDAP (RFC1798 UDP/Connectionless) support to DialURL

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -161,6 +161,11 @@ func (dc *DialContext) dial(u *url.URL) (net.Conn, error) {
 	}
 
 	switch u.Scheme {
+	case "cldap":
+		if port == "" {
+			port = DefaultLdapPort
+		}
+		return dc.d.Dial("udp", net.JoinHostPort(host, port))
 	case "ldap":
 		if port == "" {
 			port = DefaultLdapPort
@@ -203,7 +208,8 @@ func DialTLS(network, addr string, config *tls.Config) (*Conn, error) {
 }
 
 // DialURL connects to the given ldap URL.
-// The following schemas are supported: ldap://, ldaps://, ldapi://.
+// The following schemas are supported: ldap://, ldaps://, ldapi://,
+// and cldap:// (RFC1798, deprecated but used by Active Directory).
 // On success a new Conn for the connection is returned.
 func DialURL(addr string, opts ...DialOpt) (*Conn, error) {
 	u, err := url.Parse(addr)

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -161,6 +161,11 @@ func (dc *DialContext) dial(u *url.URL) (net.Conn, error) {
 	}
 
 	switch u.Scheme {
+	case "cldap":
+		if port == "" {
+			port = DefaultLdapPort
+		}
+		return dc.d.Dial("udp", net.JoinHostPort(host, port))
 	case "ldap":
 		if port == "" {
 			port = DefaultLdapPort
@@ -203,7 +208,8 @@ func DialTLS(network, addr string, config *tls.Config) (*Conn, error) {
 }
 
 // DialURL connects to the given ldap URL.
-// The following schemas are supported: ldap://, ldaps://, ldapi://.
+// The following schemas are supported: ldap://, ldaps://, ldapi://,
+// and cldap:// (RFC1798, deprecated but used by Active Directory).
 // On success a new Conn for the connection is returned.
 func DialURL(addr string, opts ...DialOpt) (*Conn, error) {
 	u, err := url.Parse(addr)


### PR DESCRIPTION
This is actually a deprecated RFC, however Active Directory relies on it for server discovery.
Without this patch CLDAP is possible via directt use of the the deprecated `Dial` function with a UDP network connection. This patch adds the same support to the DialURL function via the 'cldap' URI scheme.

See https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/8ebcf782-87fd-4dc3-8585-1301569dfe4f
and https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/895a7744-aff3-4f64-bcfa-f8c05915d2e9 for MS documentation on this.