### PR TITLE
fix: packet referral decoding

### DIFF
--- a/modify.go
+++ b/modify.go
@@ -160,11 +160,7 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	switch packet.Children[1].Tag {
 	case ApplicationModifyResponse:
 		if err = GetLDAPError(packet); err != nil {
-			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, referralErr
-			} else {
-				result.Referral = referral
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/passwdmodify.go
+++ b/passwdmodify.go
@@ -70,7 +70,6 @@ func (req *PasswordModifyRequest) appendTo(envelope *ber.Packet) error {
 // newPassword is the desired user's password. If empty the server can return
 // an error or generate a new password that will be available in the
 // PasswordModifyResult.GeneratedPassword
-//
 func NewPasswordModifyRequest(userIdentity string, oldPassword string, newPassword string) *PasswordModifyRequest {
 	return &PasswordModifyRequest{
 		UserIdentity: userIdentity,
@@ -96,11 +95,7 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		if err = GetLDAPError(packet); err != nil {
-			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, referralErr
-			} else {
-				result.Referral = referral
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -160,11 +160,7 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	switch packet.Children[1].Tag {
 	case ApplicationModifyResponse:
 		if err = GetLDAPError(packet); err != nil {
-			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, referralErr
-			} else {
-				result.Referral = referral
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}

--- a/v3/passwdmodify.go
+++ b/v3/passwdmodify.go
@@ -70,7 +70,6 @@ func (req *PasswordModifyRequest) appendTo(envelope *ber.Packet) error {
 // newPassword is the desired user's password. If empty the server can return
 // an error or generate a new password that will be available in the
 // PasswordModifyResult.GeneratedPassword
-//
 func NewPasswordModifyRequest(userIdentity string, oldPassword string, newPassword string) *PasswordModifyRequest {
 	return &PasswordModifyRequest{
 		UserIdentity: userIdentity,
@@ -96,11 +95,7 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		if err = GetLDAPError(packet); err != nil {
-			if referral, referralErr := getReferral(err, packet); referralErr != nil {
-				return result, referralErr
-			} else {
-				result.Referral = referral
-			}
+			result.Referral = getReferral(err, packet)
 
 			return result, err
 		}


### PR DESCRIPTION
This adjusts the packet referral decoding behavior to more appropriately handle edge cases and allows to more easily obtain the underlying packet in the event of a decoding error. Instead of matching ASN.1 BER packets on the tag for referrals we match on the class and type. This is particularly important in regards to OpenLDAP which returns a ASN.1 BER Generalized Time tag for referrals.

While I think this is a bug on the OpenLDAP side it's also perfectly reasonable in my opinion to handle this here as it's relatively easy to do so.