### PR TITLE
fix: parsedn not handling attributes with equal char in value

### DIFF
--- a/dn.go
+++ b/dn.go
@@ -156,7 +156,7 @@ func ParseDN(str string) (*DN, error) {
 		case char == '\\':
 			unescapedTrailingSpaces = 0
 			escaping = true
-		case char == '=':
+		case char == '=' && attribute.Type == "":
 			attribute.Type = stringFromBuffer()
 			// Special case: If the first character in the value is # the
 			// following data is BER encoded so we can just fast forward

--- a/dn_test.go
+++ b/dn_test.go
@@ -56,6 +56,10 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			{[]*AttributeTypeAndValue{{"cn", "john.doe;weird name"}}},
 			{[]*AttributeTypeAndValue{{"dc", "example"}}},
 			{[]*AttributeTypeAndValue{{"dc", "net"}}}}},
+		`cn=ZXhhbXBsZVRleHQ=,dc=dummy,dc=com`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "ZXhhbXBsZVRleHQ="}}},
+			{[]*AttributeTypeAndValue{{"dc", "dummy"}}},
+			{[]*AttributeTypeAndValue{{"dc", "com"}}}}},
 	}
 
 	for test, answer := range testcases {

--- a/v3/dn.go
+++ b/v3/dn.go
@@ -156,7 +156,7 @@ func ParseDN(str string) (*DN, error) {
 		case char == '\\':
 			unescapedTrailingSpaces = 0
 			escaping = true
-		case char == '=':
+		case char == '=' && attribute.Type == "":
 			attribute.Type = stringFromBuffer()
 			// Special case: If the first character in the value is # the
 			// following data is BER encoded so we can just fast forward

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -56,6 +56,10 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			{[]*AttributeTypeAndValue{{"cn", "john.doe;weird name"}}},
 			{[]*AttributeTypeAndValue{{"dc", "example"}}},
 			{[]*AttributeTypeAndValue{{"dc", "net"}}}}},
+		`cn=ZXhhbXBsZVRleHQ=,dc=dummy,dc=com`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "ZXhhbXBsZVRleHQ="}}},
+			{[]*AttributeTypeAndValue{{"dc", "dummy"}}},
+			{[]*AttributeTypeAndValue{{"dc", "com"}}}}},
 	}
 
 	for test, answer := range testcases {


### PR DESCRIPTION
This fixes an issue where attributes with equal chars in the value would not be correctly parsed. As we only set the AttributeTypeAndValue's Type field once and we reset it on the step to the next AttributeTypeAndValue we can assume if this field already has a value that it should not consider it the type/value separator.

Fixes #416