### PR TITLE
fix: `ParseDN` wrongly handling base64 encoded AttributeKeyValues

### DIFF
--- a/dn.go
+++ b/dn.go
@@ -156,10 +156,10 @@ func ParseDN(str string) (*DN, error) {
 		case char == '\\':
 			unescapedTrailingSpaces = 0
 			escaping = true
-		case char == '=':
+		case char == '=' && attribute.Type == "":
 			attribute.Type = stringFromBuffer()
 			// Special case: If the first character in the value is # the
-			// following data is BER encoded so we can just fast forward
+			// following data is BER encoded, so we can just fast-forward
 			// and decode.
 			if len(str) > i+1 && str[i+1] == '#' {
 				i += 2

--- a/v3/dn.go
+++ b/v3/dn.go
@@ -156,10 +156,10 @@ func ParseDN(str string) (*DN, error) {
 		case char == '\\':
 			unescapedTrailingSpaces = 0
 			escaping = true
-		case char == '=':
+		case char == '=' && attribute.Type == "":
 			attribute.Type = stringFromBuffer()
 			// Special case: If the first character in the value is # the
-			// following data is BER encoded so we can just fast forward
+			// following data is BER encoded, so we can just fast-forward
 			// and decode.
 			if len(str) > i+1 && str[i+1] == '#' {
 				i += 2


### PR DESCRIPTION
Fixes #419. This PR updates the `ParseDN` function to also take base64 encoded AttributeKeyValues into account. I also thought about decoding the Base64 encoded KV directly... but this could affect existing code as it would change the behavior.