### PR TITLE
Fix deadlocks caused by invalid connection state

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -239,7 +239,7 @@ func DialURL(addr string, opts ...DialOpt) (*Conn, error) {
 
 // NewConn returns a new Conn using conn for network I/O.
 func NewConn(conn net.Conn, isTLS bool) *Conn {
-	return &Conn{
+	l := &Conn{
 		conn:            conn,
 		chanConfirm:     make(chan struct{}),
 		chanMessageID:   make(chan int64),
@@ -248,11 +248,12 @@ func NewConn(conn net.Conn, isTLS bool) *Conn {
 		requestTimeout:  0,
 		isTLS:           isTLS,
 	}
+	l.wgClose.Add(1)
+	return l
 }
 
 // Start initializes goroutines to read responses and process messages
 func (l *Conn) Start() {
-	l.wgClose.Add(1)
 	go l.reader()
 	go l.processMessages()
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -79,6 +79,18 @@ func TestInvalidCloseStateDeadlock(t *testing.T) {
 	conn.Close()
 }
 
+// TestInvalidStateSendResponseDeadlock tests that we do not enter deadlock when the
+// message handler is blocked or inactive.
+func TestInvalidStateSendResponseDeadlock(t *testing.T) {
+	// Attempt to send a response packet when the message handler is blocked or inactive
+	msgCtx := &messageContext{
+		id:        0,
+		done:      make(chan struct{}),
+		responses: make(chan *PacketResponse),
+	}
+	msgCtx.sendResponse(&PacketResponse{})
+}
+
 // TestFinishMessage tests that we do not enter deadlock when a goroutine makes
 // a request but does not handle all responses from the server.
 func TestFinishMessage(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -58,9 +58,9 @@ func TestUnresponsiveConnection(t *testing.T) {
 	}
 }
 
-// TestInvalidCloseStateDeadlock tests that we do not enter deadlock when the
+// TestInvalidStateCloseDeadlock tests that we do not enter deadlock when the
 // message handler is blocked or inactive.
-func TestInvalidCloseStateDeadlock(t *testing.T) {
+func TestInvalidStateCloseDeadlock(t *testing.T) {
 	// The do-nothing server that accepts requests and does nothing
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))

--- a/conn_test.go
+++ b/conn_test.go
@@ -88,7 +88,7 @@ func TestInvalidStateSendResponseDeadlock(t *testing.T) {
 		done:      make(chan struct{}),
 		responses: make(chan *PacketResponse),
 	}
-	msgCtx.sendResponse(&PacketResponse{})
+	msgCtx.sendResponse(&PacketResponse{}, time.Millisecond)
 }
 
 // TestFinishMessage tests that we do not enter deadlock when a goroutine makes

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -239,7 +239,7 @@ func DialURL(addr string, opts ...DialOpt) (*Conn, error) {
 
 // NewConn returns a new Conn using conn for network I/O.
 func NewConn(conn net.Conn, isTLS bool) *Conn {
-	return &Conn{
+	l := &Conn{
 		conn:            conn,
 		chanConfirm:     make(chan struct{}),
 		chanMessageID:   make(chan int64),
@@ -248,11 +248,12 @@ func NewConn(conn net.Conn, isTLS bool) *Conn {
 		requestTimeout:  0,
 		isTLS:           isTLS,
 	}
+	l.wgClose.Add(1)
+	return l
 }
 
 // Start initializes goroutines to read responses and process messages
 func (l *Conn) Start() {
-	l.wgClose.Add(1)
 	go l.reader()
 	go l.processMessages()
 }

--- a/v3/conn_test.go
+++ b/v3/conn_test.go
@@ -79,6 +79,18 @@ func TestInvalidCloseStateDeadlock(t *testing.T) {
 	conn.Close()
 }
 
+// TestInvalidStateSendResponseDeadlock tests that we do not enter deadlock when the
+// message handler is blocked or inactive.
+func TestInvalidStateSendResponseDeadlock(t *testing.T) {
+	// Attempt to send a response packet when the message handler is blocked or inactive
+	msgCtx := &messageContext{
+		id:        0,
+		done:      make(chan struct{}),
+		responses: make(chan *PacketResponse),
+	}
+	msgCtx.sendResponse(&PacketResponse{})
+}
+
 // TestFinishMessage tests that we do not enter deadlock when a goroutine makes
 // a request but does not handle all responses from the server.
 func TestFinishMessage(t *testing.T) {

--- a/v3/conn_test.go
+++ b/v3/conn_test.go
@@ -58,9 +58,9 @@ func TestUnresponsiveConnection(t *testing.T) {
 	}
 }
 
-// TestInvalidCloseStateDeadlock tests that we do not enter deadlock when the
+// TestInvalidStateCloseDeadlock tests that we do not enter deadlock when the
 // message handler is blocked or inactive.
-func TestInvalidCloseStateDeadlock(t *testing.T) {
+func TestInvalidStateCloseDeadlock(t *testing.T) {
 	// The do-nothing server that accepts requests and does nothing
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))

--- a/v3/conn_test.go
+++ b/v3/conn_test.go
@@ -88,7 +88,7 @@ func TestInvalidStateSendResponseDeadlock(t *testing.T) {
 		done:      make(chan struct{}),
 		responses: make(chan *PacketResponse),
 	}
-	msgCtx.sendResponse(&PacketResponse{})
+	msgCtx.sendResponse(&PacketResponse{}, time.Millisecond)
 }
 
 // TestFinishMessage tests that we do not enter deadlock when a goroutine makes


### PR DESCRIPTION
We are using this library as part of a network probe, where we attempt to make an unauthenticated bind and gather some basic information about a host that appears to be listening on the standard LDAP ports. We found that in some rare cases, the connection may be killed out-of-band or black holed by an intermediary firewall.

In these cases, we identified a couple of deadlocks in the `v3.Conn.Close` and `v3.messageContext.sendResponse` methods:

```
goroutine 2045 [chan receive, 2586 minutes]:
github.com/go-ldap/ldap/v3.(*Conn).Close(0xc00d6c4d00)
	/home/runner/go/pkg/mod/github.com/go-ldap/ldap/v3@v3.4.4/conn.go:270 +0xff
```

```
goroutine 11123636 [select, 2589 minutes]:
github.com/go-ldap/ldap/v3.(*messageContext).sendResponse(...)
	/home/runner/go/pkg/mod/github.com/go-ldap/ldap/v3@v3.4.4/conn.go:64
```

This PR fixes these deadlock conditions by applying the configured timeout in both cases.