### PR TITLE
fix: return errors upon panics or receiving unexpected responses

### DIFF
--- a/add.go
+++ b/add.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -82,7 +83,7 @@ func (l *Conn) Add(addRequest *AddRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ type Client interface {
 	Start()
 	StartTLS(*tls.Config) error
 	Close() error
+	GetLastError() error
 	IsClosing() bool
 	SetTimeout(time.Duration)
 	TLSConnectionState() (tls.ConnectionState, bool)

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 type Client interface {
 	Start()
 	StartTLS(*tls.Config) error
-	Close()
+	Close() error
 	IsClosing() bool
 	SetTimeout(time.Duration)
 	TLSConnectionState() (tls.ConnectionState, bool)

--- a/conn.go
+++ b/conn.go
@@ -325,7 +325,7 @@ func (l *Conn) nextMessageID() int64 {
 }
 
 // GetLastError returns the last recorded error from goroutines like processMessages and reader.
-// Previously set errors are overridden
+// Only the last recorded error will be returned.
 func (l *Conn) GetLastError() error {
 	return l.err
 }

--- a/del.go
+++ b/del.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -51,7 +52,8 @@ func (l *Conn) Del(delRequest *DelRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
+
 	return nil
 }

--- a/moddn.go
+++ b/moddn.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -94,7 +95,8 @@ func (l *Conn) ModifyDN(m *ModifyDNRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
+
 	return nil
 }

--- a/modify.go
+++ b/modify.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"errors"
+	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -126,8 +127,9 @@ func (l *Conn) Modify(modifyRequest *ModifyRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
+
 	return nil
 }
 

--- a/v3/add.go
+++ b/v3/add.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -82,7 +83,7 @@ func (l *Conn) Add(addRequest *AddRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
 	return nil
 }

--- a/v3/client.go
+++ b/v3/client.go
@@ -10,6 +10,7 @@ type Client interface {
 	Start()
 	StartTLS(*tls.Config) error
 	Close() error
+	GetLastError() error
 	IsClosing() bool
 	SetTimeout(time.Duration)
 	TLSConnectionState() (tls.ConnectionState, bool)

--- a/v3/client.go
+++ b/v3/client.go
@@ -9,7 +9,7 @@ import (
 type Client interface {
 	Start()
 	StartTLS(*tls.Config) error
-	Close()
+	Close() error
 	IsClosing() bool
 	SetTimeout(time.Duration)
 	TLSConnectionState() (tls.ConnectionState, bool)

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -325,7 +325,7 @@ func (l *Conn) nextMessageID() int64 {
 }
 
 // GetLastError returns the last recorded error from goroutines like processMessages and reader.
-// Previously set errors are overridden
+// // Only the last recorded error will be returned.
 func (l *Conn) GetLastError() error {
 	return l.err
 }

--- a/v3/del.go
+++ b/v3/del.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -51,7 +52,8 @@ func (l *Conn) Del(delRequest *DelRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
+
 	return nil
 }

--- a/v3/moddn.go
+++ b/v3/moddn.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"fmt"
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
@@ -94,7 +95,8 @@ func (l *Conn) ModifyDN(m *ModifyDNRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
+
 	return nil
 }

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"errors"
+	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -126,8 +127,9 @@ func (l *Conn) Modify(modifyRequest *ModifyRequest) error {
 			return err
 		}
 	} else {
-		logger.Printf("Unexpected Response: %d", packet.Children[1].Tag)
+		return fmt.Errorf("ldap: unexpected response: %d", packet.Children[1].Tag)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This replaces the package-wide logger, used in places like processMessages and reader, and returns an error instead. For backwards compatibility, errors returned from goroutine functions are stored in `Conn.err` and can get retrieved through `Conn.GetLastError`.