### PR TITLE
feat: enable DirSync control in search operation

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,4 +33,5 @@ type Client interface {
 
 	Search(*SearchRequest) (*SearchResult, error)
 	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
+	DirSync(searchRequest *SearchRequest, flags, maxAttrCount int64, cookie []byte) (*SearchResult, error)
 }

--- a/control.go
+++ b/control.go
@@ -29,6 +29,16 @@ const (
 	ControlTypeMicrosoftShowDeleted = "1.2.840.113556.1.4.417"
 	// ControlTypeMicrosoftServerLinkTTL - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
 	ControlTypeMicrosoftServerLinkTTL = "1.2.840.113556.1.4.2309"
+	// ControlTypeDirSync - Active Directory DirSync - https://msdn.microsoft.com/en-us/library/aa366978(v=vs.85).aspx
+	ControlTypeDirSync = "1.2.840.113556.1.4.841"
+)
+
+// Flags for DirSync control
+const (
+	DirSyncIncrementalValues   int64 = 2147483648
+	DirSyncPublicDataOnly      int64 = 8192
+	DirSyncAncestorsFirstOrder int64 = 2048
+	DirSyncObjectSecurity      int64 = 1
 )
 
 // ControlTypeMap maps controls to text descriptions
@@ -40,6 +50,7 @@ var ControlTypeMap = map[string]string{
 	ControlTypeMicrosoftNotification:  "Change Notification - Microsoft",
 	ControlTypeMicrosoftShowDeleted:   "Show Deleted Objects - Microsoft",
 	ControlTypeMicrosoftServerLinkTTL: "Return TTL-DNs for link values with associated expiry times - Microsoft",
+	ControlTypeDirSync:                "DirSync",
 }
 
 // Control defines an interface controls provide to encode and describe themselves
@@ -490,6 +501,31 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlMicrosoftServerLinkTTL(), nil
 	case ControlTypeSubtreeDelete:
 		return NewControlSubtreeDelete(), nil
+	case ControlTypeDirSync:
+		value.Description += " (DirSync)"
+		c := new(ControlDirSync)
+		if value.Value != nil {
+			valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
+			if err != nil {
+				return nil, err
+			}
+			value.Data.Truncate(0)
+			value.Value = nil
+			value.AppendChild(valueChildren)
+		}
+		value = value.Children[0]
+		if len(value.Children) != 3 { // also on initial creation, Cookie is an empty string
+			return nil, fmt.Errorf("invalid number of children in dirSync control")
+		}
+		value.Description = "DirSync Control Value"
+		value.Children[0].Description = "Flags"
+		value.Children[1].Description = "MaxAttrCnt"
+		value.Children[2].Description = "Cookie"
+		c.Flags = value.Children[0].Value.(int64)
+		c.MaxAttrCnt = value.Children[1].Value.(int64)
+		c.Cookie = value.Children[2].Data.Bytes()
+		value.Children[2].Value = c.Cookie
+		return c, nil
 	default:
 		c := new(ControlString)
 		c.ControlType = ControlType
@@ -559,4 +595,60 @@ func encodeControls(controls []Control) *ber.Packet {
 		packet.AppendChild(control.Encode())
 	}
 	return packet
+}
+
+// ControlDirSync implements the control described in https://msdn.microsoft.com/en-us/library/aa366978(v=vs.85).aspx
+type ControlDirSync struct {
+	Flags      int64
+	MaxAttrCnt int64
+	Cookie     []byte
+}
+
+// NewControlDirSync returns a dir sync control
+func NewControlDirSync(flags int64, maxAttrCount int64, cookie []byte) *ControlDirSync {
+	return &ControlDirSync{
+		Flags:      flags,
+		MaxAttrCnt: maxAttrCount,
+		Cookie:     cookie,
+	}
+}
+
+// GetControlType returns the OID
+func (c *ControlDirSync) GetControlType() string {
+	return ControlTypeDirSync
+}
+
+// String returns a human-readable description
+func (c *ControlDirSync) String() string {
+	return fmt.Sprintf("ControlType: %s (%q), Criticality: true, ControlValue: Flags: %d, MaxAttrCnt: %d", ControlTypeMap[ControlTypeDirSync], ControlTypeDirSync, c.Flags, c.MaxAttrCnt)
+}
+
+// Encode returns the ber packet representation
+func (c *ControlDirSync) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeDirSync, "Control Type ("+ControlTypeMap[ControlTypeDirSync]+")"))
+	packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, true, "Criticality")) // must be true always
+
+	val := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (DirSync)")
+
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "DirSync Control Value")
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.Flags), "Flags"))
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.MaxAttrCnt), "MaxAttrCount"))
+
+	cookie := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "Cookie")
+	if len(c.Cookie) != 0 {
+		cookie.Value = c.Cookie
+		cookie.Data.Write(c.Cookie)
+	}
+	seq.AppendChild(cookie)
+
+	val.AppendChild(seq)
+
+	packet.AppendChild(val)
+	return packet
+}
+
+// SetCookie stores the given cookie in the dirSync control
+func (c *ControlDirSync) SetCookie(cookie []byte) {
+	c.Cookie = cookie
 }

--- a/control_test.go
+++ b/control_test.go
@@ -43,6 +43,11 @@ func TestControlString(t *testing.T) {
 	runControlTest(t, NewControlString("x", false, ""))
 }
 
+func TestControlDirSync(t *testing.T) {
+	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil))
+	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
+}
+
 func runControlTest(t *testing.T, originalControl Control) {
 	header := ""
 	if callerpc, _, line, ok := runtime.Caller(1); ok {
@@ -114,6 +119,10 @@ func TestDescribeControlString(t *testing.T) {
 	runAddControlDescriptions(t, NewControlString("x", true, ""), "Control Type ()", "Criticality")
 	runAddControlDescriptions(t, NewControlString("x", false, "y"), "Control Type ()", "Control Value")
 	runAddControlDescriptions(t, NewControlString("x", false, ""), "Control Type ()")
+}
+
+func TestDescribeControlDirSync(t *testing.T) {
+	runAddControlDescriptions(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {

--- a/examples_test.go
+++ b/examples_test.go
@@ -383,7 +383,7 @@ func ExampleConn_DirSync() {
 		if ctrl == nil || ctrl.(*ControlDirSync).Flags == 0 {
 			doMore = false
 		}
-		cookie = res.Cookie
+		cookie = ctrl.(*ControlDirSync).Cookie
 	}
 	// We're done with the initial sync. Now pull every 15 seconds for the
 	// updated entries - note that you get just the changes, not a full entry.

--- a/examples_test.go
+++ b/examples_test.go
@@ -358,6 +358,9 @@ func ExampleConn_DirSync() {
 		Username: "cn=Some User,ou=people,dc=example,dc=org",
 		Password: "MySecretPass",
 	})
+	if err != nil {
+		log.Fatalf("failed to bind: %s", err)
+	}
 
 	req := &SearchRequest{
 		BaseDN:     `DC=example,DC=org`,

--- a/search.go
+++ b/search.go
@@ -616,15 +616,9 @@ func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount i
 		return searchResult, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
 	}
 
-	for _, entry := range result.Entries {
-		searchResult.Entries = append(searchResult.Entries, entry)
-	}
-	for _, referral := range result.Referrals {
-		searchResult.Referrals = append(searchResult.Referrals, referral)
-	}
-	for _, control := range result.Controls {
-		searchResult.Controls = append(searchResult.Controls, control)
-	}
+	searchResult.Entries = append(searchResult.Entries, result.Entries...)
+	searchResult.Referrals = append(searchResult.Referrals, result.Referrals...)
+	searchResult.Controls = append(searchResult.Controls, result.Controls...)
 
 	l.Debug.Printf("Looking for DirSync Control...")
 	dirSyncResult := FindControl(result.Controls, ControlTypeDirSync)

--- a/search.go
+++ b/search.go
@@ -352,6 +352,8 @@ type SearchResult struct {
 	Referrals []string
 	// Controls are the returned controls
 	Controls []Control
+	// Cookie is the returned cookie
+	Cookie []byte
 }
 
 // Print outputs a human-readable description
@@ -581,4 +583,65 @@ func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
 	}
 
 	return entries
+}
+
+// DirSync does a Search with dirSync Control.
+func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount int64, cookie []byte) (*SearchResult, error) {
+	var dirSyncControl *ControlDirSync
+
+	control := FindControl(searchRequest.Controls, ControlTypeDirSync)
+	if control == nil {
+		dirSyncControl = NewControlDirSync(flags, maxAttrCount, cookie)
+		searchRequest.Controls = append(searchRequest.Controls, dirSyncControl)
+	} else {
+		castControl, ok := control.(*ControlDirSync)
+		if !ok {
+			return nil, fmt.Errorf("Expected DirSync control to be of type *ControlDirSync, got %v", control)
+		}
+		if castControl.Flags != flags {
+			return nil, fmt.Errorf("flags given in search request (%d) conflicts with flags given in search call (%d)", castControl.Flags, flags)
+		}
+		if castControl.MaxAttrCnt != maxAttrCount {
+			return nil, fmt.Errorf("MaxAttrCnt given in search request (%d) conflicts with maxAttrCount given in search call (%d)", castControl.MaxAttrCnt, maxAttrCount)
+		}
+		dirSyncControl = castControl
+	}
+	searchResult := new(SearchResult)
+	result, err := l.Search(searchRequest)
+	l.Debug.Printf("Looking for result...")
+	if err != nil {
+		return searchResult, err
+	}
+	if result == nil {
+		return searchResult, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
+	}
+
+	for _, entry := range result.Entries {
+		searchResult.Entries = append(searchResult.Entries, entry)
+	}
+	for _, referral := range result.Referrals {
+		searchResult.Referrals = append(searchResult.Referrals, referral)
+	}
+	for _, control := range result.Controls {
+		searchResult.Controls = append(searchResult.Controls, control)
+	}
+
+	l.Debug.Printf("Looking for DirSync Control...")
+	dirSyncResult := FindControl(result.Controls, ControlTypeDirSync)
+	if dirSyncResult == nil {
+		dirSyncControl = nil
+		l.Debug.Printf("Could not find dirSyncControl control.  Breaking...")
+		return searchResult, nil
+	}
+
+	cookie = dirSyncResult.(*ControlDirSync).Cookie
+	if len(cookie) == 0 {
+		dirSyncControl = nil
+		l.Debug.Printf("Could not find cookie.  Breaking...")
+		return searchResult, nil
+	}
+	dirSyncControl.SetCookie(cookie)
+	searchResult.Cookie = cookie
+
+	return searchResult, nil
 }

--- a/search.go
+++ b/search.go
@@ -352,8 +352,6 @@ type SearchResult struct {
 	Referrals []string
 	// Controls are the returned controls
 	Controls []Control
-	// Cookie is the returned cookie
-	Cookie []byte
 }
 
 // Print outputs a human-readable description
@@ -635,7 +633,6 @@ func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount i
 		return searchResult, nil
 	}
 	dirSyncControl.SetCookie(cookie)
-	searchResult.Cookie = cookie
 
 	return searchResult, nil
 }

--- a/v3/client.go
+++ b/v3/client.go
@@ -33,4 +33,5 @@ type Client interface {
 
 	Search(*SearchRequest) (*SearchResult, error)
 	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
+	DirSync(searchRequest *SearchRequest, flags, maxAttrCount int64, cookie []byte) (*SearchResult, error)
 }

--- a/v3/control.go
+++ b/v3/control.go
@@ -34,6 +34,16 @@ const (
 	ControlTypeMicrosoftShowDeleted = "1.2.840.113556.1.4.417"
 	// ControlTypeMicrosoftServerLinkTTL - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/f4f523a8-abc0-4b3a-a471-6b2fef135481?redirectedfrom=MSDN
 	ControlTypeMicrosoftServerLinkTTL = "1.2.840.113556.1.4.2309"
+	// ControlTypeDirSync - Active Directory DirSync - https://msdn.microsoft.com/en-us/library/aa366978(v=vs.85).aspx
+	ControlTypeDirSync = "1.2.840.113556.1.4.841"
+)
+
+// Flags for DirSync control
+const (
+	DirSyncIncrementalValues   int64 = 2147483648
+	DirSyncPublicDataOnly      int64 = 8192
+	DirSyncAncestorsFirstOrder int64 = 2048
+	DirSyncObjectSecurity      int64 = 1
 )
 
 // ControlTypeMap maps controls to text descriptions
@@ -47,6 +57,7 @@ var ControlTypeMap = map[string]string{
 	ControlTypeMicrosoftServerLinkTTL:  "Return TTL-DNs for link values with associated expiry times - Microsoft",
 	ControlTypeServerSideSorting:       "Server Side Sorting Request - LDAP Control Extension for Server Side Sorting of Search Results (RFC2891)",
 	ControlTypeServerSideSortingResult: "Server Side Sorting Results - LDAP Control Extension for Server Side Sorting of Search Results (RFC2891)",
+	ControlTypeDirSync:                 "DirSync",
 }
 
 // Control defines an interface controls provide to encode and describe themselves
@@ -501,6 +512,31 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlServerSideSorting(value)
 	case ControlTypeServerSideSortingResult:
 		return NewControlServerSideSortingResult(value)
+	case ControlTypeDirSync:
+		value.Description += " (DirSync)"
+		c := new(ControlDirSync)
+		if value.Value != nil {
+			valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
+			if err != nil {
+				return nil, err
+			}
+			value.Data.Truncate(0)
+			value.Value = nil
+			value.AppendChild(valueChildren)
+		}
+		value = value.Children[0]
+		if len(value.Children) != 3 { // also on initial creation, Cookie is an empty string
+			return nil, fmt.Errorf("invalid number of children in dirSync control")
+		}
+		value.Description = "DirSync Control Value"
+		value.Children[0].Description = "Flags"
+		value.Children[1].Description = "MaxAttrCnt"
+		value.Children[2].Description = "Cookie"
+		c.Flags = value.Children[0].Value.(int64)
+		c.MaxAttrCnt = value.Children[1].Value.(int64)
+		c.Cookie = value.Children[2].Data.Bytes()
+		value.Children[2].Value = c.Cookie
+		return c, nil
 	default:
 		c := new(ControlString)
 		c.ControlType = ControlType
@@ -570,6 +606,62 @@ func encodeControls(controls []Control) *ber.Packet {
 		packet.AppendChild(control.Encode())
 	}
 	return packet
+}
+
+// ControlDirSync implements the control described in https://msdn.microsoft.com/en-us/library/aa366978(v=vs.85).aspx
+type ControlDirSync struct {
+	Flags      int64
+	MaxAttrCnt int64
+	Cookie     []byte
+}
+
+// NewControlDirSync returns a dir sync control
+func NewControlDirSync(flags int64, maxAttrCount int64, cookie []byte) *ControlDirSync {
+	return &ControlDirSync{
+		Flags:      flags,
+		MaxAttrCnt: maxAttrCount,
+		Cookie:     cookie,
+	}
+}
+
+// GetControlType returns the OID
+func (c *ControlDirSync) GetControlType() string {
+	return ControlTypeDirSync
+}
+
+// String returns a human-readable description
+func (c *ControlDirSync) String() string {
+	return fmt.Sprintf("ControlType: %s (%q), Criticality: true, ControlValue: Flags: %d, MaxAttrCnt: %d", ControlTypeMap[ControlTypeDirSync], ControlTypeDirSync, c.Flags, c.MaxAttrCnt)
+}
+
+// Encode returns the ber packet representation
+func (c *ControlDirSync) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeDirSync, "Control Type ("+ControlTypeMap[ControlTypeDirSync]+")"))
+	packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, true, "Criticality")) // must be true always
+
+	val := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (DirSync)")
+
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "DirSync Control Value")
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.Flags), "Flags"))
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.MaxAttrCnt), "MaxAttrCount"))
+
+	cookie := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "Cookie")
+	if len(c.Cookie) != 0 {
+		cookie.Value = c.Cookie
+		cookie.Data.Write(c.Cookie)
+	}
+	seq.AppendChild(cookie)
+
+	val.AppendChild(seq)
+
+	packet.AppendChild(val)
+	return packet
+}
+
+// SetCookie stores the given cookie in the dirSync control
+func (c *ControlDirSync) SetCookie(cookie []byte) {
+	c.Cookie = cookie
 }
 
 // ControlServerSideSorting

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -43,6 +43,11 @@ func TestControlString(t *testing.T) {
 	runControlTest(t, NewControlString("x", false, ""))
 }
 
+func TestControlDirSync(t *testing.T) {
+	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil))
+	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
+}
+
 func runControlTest(t *testing.T, originalControl Control) {
 	header := ""
 	if callerpc, _, line, ok := runtime.Caller(1); ok {
@@ -114,6 +119,10 @@ func TestDescribeControlString(t *testing.T) {
 	runAddControlDescriptions(t, NewControlString("x", true, ""), "Control Type ()", "Criticality")
 	runAddControlDescriptions(t, NewControlString("x", false, "y"), "Control Type ()", "Control Value")
 	runAddControlDescriptions(t, NewControlString("x", false, ""), "Control Type ()")
+}
+
+func TestDescribeControlDirSync(t *testing.T) {
+	runAddControlDescriptions(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {

--- a/v3/examples_test.go
+++ b/v3/examples_test.go
@@ -383,7 +383,7 @@ func ExampleConn_DirSync() {
 		if ctrl == nil || ctrl.(*ControlDirSync).Flags == 0 {
 			doMore = false
 		}
-		cookie = res.Cookie
+		cookie = ctrl.(*ControlDirSync).Cookie
 	}
 	// We're done with the initial sync. Now pull every 15 seconds for the
 	// updated entries - note that you get just the changes, not a full entry.

--- a/v3/examples_test.go
+++ b/v3/examples_test.go
@@ -358,6 +358,9 @@ func ExampleConn_DirSync() {
 		Username: "cn=Some User,ou=people,dc=example,dc=org",
 		Password: "MySecretPass",
 	})
+	if err != nil {
+		log.Fatalf("failed to bind: %s", err)
+	}
 
 	req := &SearchRequest{
 		BaseDN:     `DC=example,DC=org`,

--- a/v3/search.go
+++ b/v3/search.go
@@ -354,8 +354,6 @@ type SearchResult struct {
 	Referrals []string
 	// Controls are the returned controls
 	Controls []Control
-	// Cookie is the returned cookie
-	Cookie []byte
 }
 
 // Print outputs a human-readable description
@@ -637,7 +635,6 @@ func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount i
 		return searchResult, nil
 	}
 	dirSyncControl.SetCookie(cookie)
-	searchResult.Cookie = cookie
 
 	return searchResult, nil
 }

--- a/v3/search.go
+++ b/v3/search.go
@@ -618,15 +618,9 @@ func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount i
 		return searchResult, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
 	}
 
-	for _, entry := range result.Entries {
-		searchResult.Entries = append(searchResult.Entries, entry)
-	}
-	for _, referral := range result.Referrals {
-		searchResult.Referrals = append(searchResult.Referrals, referral)
-	}
-	for _, control := range result.Controls {
-		searchResult.Controls = append(searchResult.Controls, control)
-	}
+	searchResult.Entries = append(searchResult.Entries, result.Entries...)
+	searchResult.Referrals = append(searchResult.Referrals, result.Referrals...)
+	searchResult.Controls = append(searchResult.Controls, result.Controls...)
 
 	l.Debug.Printf("Looking for DirSync Control...")
 	dirSyncResult := FindControl(result.Controls, ControlTypeDirSync)

--- a/v3/search.go
+++ b/v3/search.go
@@ -354,6 +354,8 @@ type SearchResult struct {
 	Referrals []string
 	// Controls are the returned controls
 	Controls []Control
+	// Cookie is the returned cookie
+	Cookie []byte
 }
 
 // Print outputs a human-readable description
@@ -583,4 +585,65 @@ func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
 	}
 
 	return entries
+}
+
+// DirSync does a Search with dirSync Control.
+func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount int64, cookie []byte) (*SearchResult, error) {
+	var dirSyncControl *ControlDirSync
+
+	control := FindControl(searchRequest.Controls, ControlTypeDirSync)
+	if control == nil {
+		dirSyncControl = NewControlDirSync(flags, maxAttrCount, cookie)
+		searchRequest.Controls = append(searchRequest.Controls, dirSyncControl)
+	} else {
+		castControl, ok := control.(*ControlDirSync)
+		if !ok {
+			return nil, fmt.Errorf("Expected DirSync control to be of type *ControlDirSync, got %v", control)
+		}
+		if castControl.Flags != flags {
+			return nil, fmt.Errorf("flags given in search request (%d) conflicts with flags given in search call (%d)", castControl.Flags, flags)
+		}
+		if castControl.MaxAttrCnt != maxAttrCount {
+			return nil, fmt.Errorf("MaxAttrCnt given in search request (%d) conflicts with maxAttrCount given in search call (%d)", castControl.MaxAttrCnt, maxAttrCount)
+		}
+		dirSyncControl = castControl
+	}
+	searchResult := new(SearchResult)
+	result, err := l.Search(searchRequest)
+	l.Debug.Printf("Looking for result...")
+	if err != nil {
+		return searchResult, err
+	}
+	if result == nil {
+		return searchResult, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
+	}
+
+	for _, entry := range result.Entries {
+		searchResult.Entries = append(searchResult.Entries, entry)
+	}
+	for _, referral := range result.Referrals {
+		searchResult.Referrals = append(searchResult.Referrals, referral)
+	}
+	for _, control := range result.Controls {
+		searchResult.Controls = append(searchResult.Controls, control)
+	}
+
+	l.Debug.Printf("Looking for DirSync Control...")
+	dirSyncResult := FindControl(result.Controls, ControlTypeDirSync)
+	if dirSyncResult == nil {
+		dirSyncControl = nil
+		l.Debug.Printf("Could not find dirSyncControl control.  Breaking...")
+		return searchResult, nil
+	}
+
+	cookie = dirSyncResult.(*ControlDirSync).Cookie
+	if len(cookie) == 0 {
+		dirSyncControl = nil
+		l.Debug.Printf("Could not find cookie.  Breaking...")
+		return searchResult, nil
+	}
+	dirSyncControl.SetCookie(cookie)
+	searchResult.Cookie = cookie
+
+	return searchResult, nil
 }


### PR DESCRIPTION
This pull request enables go-ldap to search with DirSync control.

This request was referenced below, but the Cookie process was changed from the following request. The reason is to allow the search to resume from the Cookie.

Please check the test for the usage.

reference: 
* https://github.com/go-ldap/ldap/pull/110
* https://learn.microsoft.com/ja-jp/previous-versions/windows/desktop/ldap/ldap-server-dirsync-oid?redirectedfrom=MSDN