### PR TITLE
fix: remove trailing nul character at the end of ActiveDirectory errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"fmt"
+	"strings"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -210,10 +211,12 @@ func GetLDAPError(packet *ber.Packet) error {
 			if resultCode == 0 { // No error
 				return nil
 			}
+
+			errorMsg := strings.Trim(response.Children[2].Value.(string), "\x00")
 			return &Error{
 				ResultCode: resultCode,
 				MatchedDN:  response.Children[1].Value.(string),
-				Err:        fmt.Errorf("%s", response.Children[2].Value.(string)),
+				Err:        fmt.Errorf("%s", errorMsg),
 				Packet:     packet,
 			}
 		}

--- a/v3/error.go
+++ b/v3/error.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"fmt"
+	"strings"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -210,10 +211,11 @@ func GetLDAPError(packet *ber.Packet) error {
 			if resultCode == 0 { // No error
 				return nil
 			}
+			errorMsg := strings.Trim(response.Children[2].Value.(string), "\x00")
 			return &Error{
 				ResultCode: resultCode,
 				MatchedDN:  response.Children[1].Value.(string),
-				Err:        fmt.Errorf("%s", response.Children[2].Value.(string)),
+				Err:        fmt.Errorf("%s", errorMsg),
 				Packet:     packet,
 			}
 		}


### PR DESCRIPTION
This PR is to remove the trailing nul character added by ActiveDirectory when returning errors messages.

From Wireshark you can see it in the LDAP response:
![image](https://github.com/go-ldap/ldap/assets/16674565/d054ef2b-e670-4ebd-9f95-c115fff43405)

Then if I write the LDAP error from go-ldap into a file:
![image](https://github.com/go-ldap/ldap/assets/16674565/ec97f7ea-ea52-4393-886d-fb9034258451)
![image](https://github.com/go-ldap/ldap/assets/16674565/ddca9060-2779-4a09-b589-1402f8f7b880)

