### PR TITLE
Fix a deadlock issue using search asynchronously

### DIFF
--- a/response.go
+++ b/response.go
@@ -60,10 +60,6 @@ func (r *searchResponse) Next() bool {
 	if r.err != nil {
 		return false
 	}
-	r.err = r.conn.GetLastError()
-	if r.err != nil {
-		return false
-	}
 	r.entry = res.Entry
 	r.referral = res.Referral
 	r.controls = res.Controls

--- a/v3/response.go
+++ b/v3/response.go
@@ -60,10 +60,6 @@ func (r *searchResponse) Next() bool {
 	if r.err != nil {
 		return false
 	}
-	r.err = r.conn.GetLastError()
-	if r.err != nil {
-		return false
-	}
 	r.entry = res.Entry
 	r.referral = res.Referral
 	r.controls = res.Controls


### PR DESCRIPTION
The previous change is merged from #440. 

I'm implementing #422 using the search asynchronous feature. I found a deadlock issue with the low-sized buffered channel in my local environment. When the buffered channel is full, a goroutine waits to send to the channel. But sometimes, searchResponse.Next() occurs deadlock since the messageMutex cannot get a lock in Conn.GetLastError().

While working at #440, I found Conn.err is a race condition. So I added messageMutex.Lock() code, which causes a deadlock issue with certain conditions (e.g., a low-sized buffered channel). That makes a more complicated problem.

~This code is young, and we can revert quickly.~