### PR TITLE
[Fuzzing] Add fuzz testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ quicktest:
 fuzz:
 	go test -fuzz=FuzzParseDN				-fuzztime=600s .
 	go test -fuzz=FuzzDecodeEscapedSymbols	-fuzztime=600s .
-	go test -fuzz=FuzzEscapeFilter 			-fuzztime=600s .
 	go test -fuzz=FuzzEscapeDN 				-fuzztime=600s .
 
 # Capture output and force failure when there is non-empty output

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ test:
 quicktest:
 	go test ./...
 
+fuzz:
+	go test -fuzz=FuzzParseDN				-fuzztime=600s .
+	go test -fuzz=FuzzDecodeEscapedSymbols	-fuzztime=600s .
+	go test -fuzz=FuzzEscapeFilter 			-fuzztime=600s .
+	go test -fuzz=FuzzEscapeDN 				-fuzztime=600s .
+
 # Capture output and force failure when there is non-empty output
 fmt:
 	@echo gofmt -l .

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -31,16 +31,6 @@ func FuzzDecodeEscapedSymbols(f *testing.F) {
 	})
 }
 
-func FuzzEscapeFilter(f *testing.F) {
-
-	f.Add("a\x00b(c)d*e\\f")
-	f.Add("Lučić")
-
-	f.Fuzz(func(t *testing.T, input_data string) {
-		_ = EscapeFilter(input_data)
-	})
-}
-
 func FuzzEscapeDN(f *testing.F) {
 
 	f.Add("test,user")

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,57 @@
+//go:build go1.18
+// +build go1.18
+
+package ldap
+
+import "testing"
+
+func FuzzParseDN(f *testing.F) {
+
+	f.Add("*")
+	f.Add("cn=Jim\\0Test")
+	f.Add("cn=Jim\\0")
+	f.Add("DC=example,=net")
+	f.Add("o=a+o=B")
+
+	f.Fuzz(func(t *testing.T, input_data string) {
+		_, _ = ParseDN(input_data)
+	})
+}
+
+func FuzzDecodeEscapedSymbols(f *testing.F) {
+
+	f.Add([]byte("a\u0100\x80"))
+	f.Add([]byte(`start\d`))
+	f.Add([]byte(`\`))
+	f.Add([]byte(`start\--end`))
+	f.Add([]byte(`start\d0\hh`))
+
+	f.Fuzz(func(t *testing.T, input_data []byte) {
+		_, _ = decodeEscapedSymbols(input_data)
+	})
+}
+
+func FuzzEscapeFilter(f *testing.F) {
+
+	f.Add("a\x00b(c)d*e\\f")
+	f.Add("Lučić")
+
+	f.Fuzz(func(t *testing.T, input_data string) {
+		_ = EscapeFilter(input_data)
+	})
+}
+
+func FuzzEscapeDN(f *testing.F) {
+
+	f.Add("test,user")
+	f.Add("#test#user#")
+	f.Add("\\test\\user\\")
+	f.Add("  test user  ")
+	f.Add("\u0000te\x00st\x00user" + string(rune(0)))
+	f.Add("test\"+,;<>\\-_user")
+	f.Add("test\u0391user ")
+
+	f.Fuzz(func(t *testing.T, input_data string) {
+		_ = EscapeDN(input_data)
+	})
+}


### PR DESCRIPTION
using [go-fuzz](https://go.dev/security/fuzz) for fuzz testing of `ldap`



#### Error:

"PR / Go 1.16.x PR Validate . (Modules) (pull_request) Failing after 17s:"
```
vet: ./dn_test.go:294:29: F not declared by package testing
Error: Process completed with exit code 2.
```
Go-fuzz was introduce  in `Go 1.18`.
 
