### PR TITLE
Refactor DirSync search process

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,5 +36,6 @@ type Client interface {
 	SearchAsync(ctx context.Context, searchRequest *SearchRequest, bufferSize int) Response
 	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
 	DirSync(searchRequest *SearchRequest, flags, maxAttrCount int64, cookie []byte) (*SearchResult, error)
+	DirSyncAsync(ctx context.Context, searchRequest *SearchRequest, bufferSize int, flags, maxAttrCount int64, cookie []byte) Response
 	Syncrepl(ctx context.Context, searchRequest *SearchRequest, bufferSize int, mode ControlSyncRequestMode, cookie []byte, reloadHint bool) Response
 }

--- a/control.go
+++ b/control.go
@@ -624,6 +624,11 @@ type ControlDirSync struct {
 	Cookie       []byte
 }
 
+// @deprecated Use NewRequestControlDirSync instead
+func NewControlDirSync(flags int64, maxAttrCount int64, cookie []byte) *ControlDirSync {
+	return NewRequestControlDirSync(flags, maxAttrCount, cookie)
+}
+
 // NewRequestControlDirSync returns a dir sync control
 func NewRequestControlDirSync(
 	flags int64, maxAttrCount int64, cookie []byte,

--- a/control.go
+++ b/control.go
@@ -523,7 +523,7 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlSubtreeDelete(), nil
 	case ControlTypeDirSync:
 		value.Description += " (DirSync)"
-		return NewControlDirSyncForDecode(value)
+		return NewResponseControlDirSync(value)
 	case ControlTypeSyncState:
 		value.Description += " (Sync State)"
 		valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
@@ -624,8 +624,8 @@ type ControlDirSync struct {
 	Cookie       []byte
 }
 
-// NewControlDirSyncForEncode returns a dir sync control
-func NewControlDirSyncForEncode(
+// NewRequestControlDirSync returns a dir sync control
+func NewRequestControlDirSync(
 	flags int64, maxAttrCount int64, cookie []byte,
 ) *ControlDirSync {
 	return &ControlDirSync{
@@ -636,8 +636,8 @@ func NewControlDirSyncForEncode(
 	}
 }
 
-// NewControlDirSyncForDecode returns a dir sync control
-func NewControlDirSyncForDecode(value *ber.Packet) (*ControlDirSync, error) {
+// NewResponseControlDirSync returns a dir sync control
+func NewResponseControlDirSync(value *ber.Packet) (*ControlDirSync, error) {
 	if value.Value != nil {
 		valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
 		if err != nil {

--- a/control_test.go
+++ b/control_test.go
@@ -44,8 +44,8 @@ func TestControlString(t *testing.T) {
 }
 
 func TestControlDirSync(t *testing.T) {
-	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil))
-	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
+	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil))
+	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
 }
 
 func runControlTest(t *testing.T, originalControl Control) {
@@ -122,7 +122,7 @@ func TestDescribeControlString(t *testing.T) {
 }
 
 func TestDescribeControlDirSync(t *testing.T) {
-	runAddControlDescriptions(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
+	runAddControlDescriptions(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {

--- a/control_test.go
+++ b/control_test.go
@@ -44,8 +44,8 @@ func TestControlString(t *testing.T) {
 }
 
 func TestControlDirSync(t *testing.T) {
-	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil))
-	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
+	runControlTest(t, NewRequestControlDirSync(DirSyncObjectSecurity, 1000, nil))
+	runControlTest(t, NewRequestControlDirSync(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
 }
 
 func runControlTest(t *testing.T, originalControl Control) {
@@ -122,7 +122,7 @@ func TestDescribeControlString(t *testing.T) {
 }
 
 func TestDescribeControlDirSync(t *testing.T) {
-	runAddControlDescriptions(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
+	runAddControlDescriptions(t, NewRequestControlDirSync(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {

--- a/search.go
+++ b/search.go
@@ -638,7 +638,7 @@ func (l *Conn) DirSync(
 ) (*SearchResult, error) {
 	control := FindControl(searchRequest.Controls, ControlTypeDirSync)
 	if control == nil {
-		c := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+		c := NewRequestControlDirSync(flags, maxAttrCount, cookie)
 		searchRequest.Controls = append(searchRequest.Controls, c)
 	} else {
 		c := control.(*ControlDirSync)
@@ -680,7 +680,7 @@ func (l *Conn) DirSyncAsync(
 	ctx context.Context, searchRequest *SearchRequest, bufferSize int,
 	flags, maxAttrCount int64, cookie []byte,
 ) Response {
-	control := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+	control := NewRequestControlDirSync(flags, maxAttrCount, cookie)
 	searchRequest.Controls = append(searchRequest.Controls, control)
 	r := newSearchResponse(l, bufferSize)
 	r.start(ctx, searchRequest)

--- a/search.go
+++ b/search.go
@@ -633,55 +633,56 @@ func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
 }
 
 // DirSync does a Search with dirSync Control.
-func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount int64, cookie []byte) (*SearchResult, error) {
-	var dirSyncControl *ControlDirSync
-
+func (l *Conn) DirSync(
+	searchRequest *SearchRequest, flags int64, maxAttrCount int64, cookie []byte,
+) (*SearchResult, error) {
 	control := FindControl(searchRequest.Controls, ControlTypeDirSync)
 	if control == nil {
-		dirSyncControl = NewControlDirSync(flags, maxAttrCount, cookie)
-		searchRequest.Controls = append(searchRequest.Controls, dirSyncControl)
+		c := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+		searchRequest.Controls = append(searchRequest.Controls, c)
 	} else {
-		castControl, ok := control.(*ControlDirSync)
-		if !ok {
-			return nil, fmt.Errorf("Expected DirSync control to be of type *ControlDirSync, got %v", control)
+		c := control.(*ControlDirSync)
+		if c.Flags != flags {
+			return nil, fmt.Errorf("flags given in search request (%d) conflicts with flags given in search call (%d)", c.Flags, flags)
 		}
-		if castControl.Flags != flags {
-			return nil, fmt.Errorf("flags given in search request (%d) conflicts with flags given in search call (%d)", castControl.Flags, flags)
+		if c.MaxAttrCount != maxAttrCount {
+			return nil, fmt.Errorf("MaxAttrCnt given in search request (%d) conflicts with maxAttrCount given in search call (%d)", c.MaxAttrCount, maxAttrCount)
 		}
-		if castControl.MaxAttrCnt != maxAttrCount {
-			return nil, fmt.Errorf("MaxAttrCnt given in search request (%d) conflicts with maxAttrCount given in search call (%d)", castControl.MaxAttrCnt, maxAttrCount)
-		}
-		dirSyncControl = castControl
 	}
-	searchResult := new(SearchResult)
-	result, err := l.Search(searchRequest)
+	searchResult, err := l.Search(searchRequest)
 	l.Debug.Printf("Looking for result...")
 	if err != nil {
-		return searchResult, err
+		return nil, err
 	}
-	if result == nil {
-		return searchResult, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
+	if searchResult == nil {
+		return nil, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
 	}
-
-	searchResult.Entries = append(searchResult.Entries, result.Entries...)
-	searchResult.Referrals = append(searchResult.Referrals, result.Referrals...)
-	searchResult.Controls = append(searchResult.Controls, result.Controls...)
 
 	l.Debug.Printf("Looking for DirSync Control...")
-	dirSyncResult := FindControl(result.Controls, ControlTypeDirSync)
-	if dirSyncResult == nil {
-		dirSyncControl = nil
+	resultControl := FindControl(searchResult.Controls, ControlTypeDirSync)
+	if resultControl == nil {
 		l.Debug.Printf("Could not find dirSyncControl control.  Breaking...")
 		return searchResult, nil
 	}
 
-	cookie = dirSyncResult.(*ControlDirSync).Cookie
+	cookie = resultControl.(*ControlDirSync).Cookie
 	if len(cookie) == 0 {
-		dirSyncControl = nil
 		l.Debug.Printf("Could not find cookie.  Breaking...")
 		return searchResult, nil
 	}
-	dirSyncControl.SetCookie(cookie)
 
 	return searchResult, nil
+}
+
+// DirSyncDirSyncAsync performs a search request and returns all search results
+// asynchronously. This is efficient when the server returns lots of entries.
+func (l *Conn) DirSyncAsync(
+	ctx context.Context, searchRequest *SearchRequest, bufferSize int,
+	flags, maxAttrCount int64, cookie []byte,
+) Response {
+	control := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+	searchRequest.Controls = append(searchRequest.Controls, control)
+	r := newSearchResponse(l, bufferSize)
+	r.start(ctx, searchRequest)
+	return r
 }

--- a/v3/client.go
+++ b/v3/client.go
@@ -36,5 +36,6 @@ type Client interface {
 	SearchAsync(ctx context.Context, searchRequest *SearchRequest, bufferSize int) Response
 	SearchWithPaging(searchRequest *SearchRequest, pagingSize uint32) (*SearchResult, error)
 	DirSync(searchRequest *SearchRequest, flags, maxAttrCount int64, cookie []byte) (*SearchResult, error)
+	DirSyncAsync(ctx context.Context, searchRequest *SearchRequest, bufferSize int, flags, maxAttrCount int64, cookie []byte) Response
 	Syncrepl(ctx context.Context, searchRequest *SearchRequest, bufferSize int, mode ControlSyncRequestMode, cookie []byte, reloadHint bool) Response
 }

--- a/v3/control.go
+++ b/v3/control.go
@@ -534,7 +534,7 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlServerSideSortingResult(value)
 	case ControlTypeDirSync:
 		value.Description += " (DirSync)"
-		return NewControlDirSyncForDecode(value)
+		return NewResponseControlDirSync(value)
 	case ControlTypeSyncState:
 		value.Description += " (Sync State)"
 		valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
@@ -635,8 +635,8 @@ type ControlDirSync struct {
 	Cookie       []byte
 }
 
-// NewControlDirSyncForEncode returns a dir sync control
-func NewControlDirSyncForEncode(
+// NewRequestControlDirSync returns a dir sync control
+func NewRequestControlDirSync(
 	flags int64, maxAttrCount int64, cookie []byte,
 ) *ControlDirSync {
 	return &ControlDirSync{
@@ -647,8 +647,8 @@ func NewControlDirSyncForEncode(
 	}
 }
 
-// NewControlDirSyncForDecode returns a dir sync control
-func NewControlDirSyncForDecode(value *ber.Packet) (*ControlDirSync, error) {
+// NewResponseControlDirSync returns a dir sync control
+func NewResponseControlDirSync(value *ber.Packet) (*ControlDirSync, error) {
 	if value.Value != nil {
 		valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
 		if err != nil {

--- a/v3/control.go
+++ b/v3/control.go
@@ -534,29 +534,7 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		return NewControlServerSideSortingResult(value)
 	case ControlTypeDirSync:
 		value.Description += " (DirSync)"
-		c := new(ControlDirSync)
-		if value.Value != nil {
-			valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
-			if err != nil {
-				return nil, err
-			}
-			value.Data.Truncate(0)
-			value.Value = nil
-			value.AppendChild(valueChildren)
-		}
-		value = value.Children[0]
-		if len(value.Children) != 3 { // also on initial creation, Cookie is an empty string
-			return nil, fmt.Errorf("invalid number of children in dirSync control")
-		}
-		value.Description = "DirSync Control Value"
-		value.Children[0].Description = "Flags"
-		value.Children[1].Description = "MaxAttrCnt"
-		value.Children[2].Description = "Cookie"
-		c.Flags = value.Children[0].Value.(int64)
-		c.MaxAttrCnt = value.Children[1].Value.(int64)
-		c.Cookie = value.Children[2].Data.Bytes()
-		value.Children[2].Value = c.Cookie
-		return c, nil
+		return NewControlDirSyncForDecode(value)
 	case ControlTypeSyncState:
 		value.Description += " (Sync State)"
 		valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
@@ -651,18 +629,52 @@ func encodeControls(controls []Control) *ber.Packet {
 
 // ControlDirSync implements the control described in https://msdn.microsoft.com/en-us/library/aa366978(v=vs.85).aspx
 type ControlDirSync struct {
-	Flags      int64
-	MaxAttrCnt int64
-	Cookie     []byte
+	Criticality  bool
+	Flags        int64
+	MaxAttrCount int64
+	Cookie       []byte
 }
 
-// NewControlDirSync returns a dir sync control
-func NewControlDirSync(flags int64, maxAttrCount int64, cookie []byte) *ControlDirSync {
+// NewControlDirSyncForEncode returns a dir sync control
+func NewControlDirSyncForEncode(
+	flags int64, maxAttrCount int64, cookie []byte,
+) *ControlDirSync {
 	return &ControlDirSync{
-		Flags:      flags,
-		MaxAttrCnt: maxAttrCount,
-		Cookie:     cookie,
+		Criticality:  true,
+		Flags:        flags,
+		MaxAttrCount: maxAttrCount,
+		Cookie:       cookie,
 	}
+}
+
+// NewControlDirSyncForDecode returns a dir sync control
+func NewControlDirSyncForDecode(value *ber.Packet) (*ControlDirSync, error) {
+	if value.Value != nil {
+		valueChildren, err := ber.DecodePacketErr(value.Data.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode data bytes: %s", err)
+		}
+		value.Data.Truncate(0)
+		value.Value = nil
+		value.AppendChild(valueChildren)
+	}
+	child := value.Children[0]
+	if len(child.Children) != 3 { // also on initial creation, Cookie is an empty string
+		return nil, fmt.Errorf("invalid number of children in dirSync control")
+	}
+	child.Description = "DirSync Control Value"
+	child.Children[0].Description = "Flags"
+	child.Children[1].Description = "MaxAttrCount"
+	child.Children[2].Description = "Cookie"
+
+	cookie := child.Children[2].Data.Bytes()
+	child.Children[2].Value = cookie
+	return &ControlDirSync{
+		Criticality:  true,
+		Flags:        child.Children[0].Value.(int64),
+		MaxAttrCount: child.Children[1].Value.(int64),
+		Cookie:       cookie,
+	}, nil
 }
 
 // GetControlType returns the OID
@@ -672,28 +684,33 @@ func (c *ControlDirSync) GetControlType() string {
 
 // String returns a human-readable description
 func (c *ControlDirSync) String() string {
-	return fmt.Sprintf("ControlType: %s (%q), Criticality: true, ControlValue: Flags: %d, MaxAttrCnt: %d", ControlTypeMap[ControlTypeDirSync], ControlTypeDirSync, c.Flags, c.MaxAttrCnt)
+	return fmt.Sprintf(
+		"ControlType: %s (%q) Criticality: %t ControlValue: Flags: %d MaxAttrCount: %d",
+		ControlTypeMap[ControlTypeDirSync],
+		ControlTypeDirSync,
+		c.Criticality,
+		c.Flags,
+		c.MaxAttrCount,
+	)
 }
 
 // Encode returns the ber packet representation
 func (c *ControlDirSync) Encode() *ber.Packet {
-	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
-	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeDirSync, "Control Type ("+ControlTypeMap[ControlTypeDirSync]+")"))
-	packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, true, "Criticality")) // must be true always
-
-	val := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (DirSync)")
-
-	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "DirSync Control Value")
-	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.Flags), "Flags"))
-	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.MaxAttrCnt), "MaxAttrCount"))
-
 	cookie := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "Cookie")
 	if len(c.Cookie) != 0 {
 		cookie.Value = c.Cookie
 		cookie.Data.Write(c.Cookie)
 	}
-	seq.AppendChild(cookie)
 
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeDirSync, "Control Type ("+ControlTypeMap[ControlTypeDirSync]+")"))
+	packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality")) // must be true always
+
+	val := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (DirSync)")
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "DirSync Control Value")
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.Flags), "Flags"))
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(c.MaxAttrCount), "MaxAttrCount"))
+	seq.AppendChild(cookie)
 	val.AppendChild(seq)
 
 	packet.AppendChild(val)

--- a/v3/control.go
+++ b/v3/control.go
@@ -635,6 +635,11 @@ type ControlDirSync struct {
 	Cookie       []byte
 }
 
+// @deprecated Use NewRequestControlDirSync instead
+func NewControlDirSync(flags int64, maxAttrCount int64, cookie []byte) *ControlDirSync {
+	return NewRequestControlDirSync(flags, maxAttrCount, cookie)
+}
+
 // NewRequestControlDirSync returns a dir sync control
 func NewRequestControlDirSync(
 	flags int64, maxAttrCount int64, cookie []byte,

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -44,8 +44,8 @@ func TestControlString(t *testing.T) {
 }
 
 func TestControlDirSync(t *testing.T) {
-	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil))
-	runControlTest(t, NewControlDirSync(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
+	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil))
+	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
 }
 
 func runControlTest(t *testing.T, originalControl Control) {
@@ -122,7 +122,7 @@ func TestDescribeControlString(t *testing.T) {
 }
 
 func TestDescribeControlDirSync(t *testing.T) {
-	runAddControlDescriptions(t, NewControlDirSync(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
+	runAddControlDescriptions(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -44,8 +44,8 @@ func TestControlString(t *testing.T) {
 }
 
 func TestControlDirSync(t *testing.T) {
-	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil))
-	runControlTest(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
+	runControlTest(t, NewRequestControlDirSync(DirSyncObjectSecurity, 1000, nil))
+	runControlTest(t, NewRequestControlDirSync(DirSyncObjectSecurity, 1000, []byte("I'm a cookie!")))
 }
 
 func runControlTest(t *testing.T, originalControl Control) {
@@ -122,7 +122,7 @@ func TestDescribeControlString(t *testing.T) {
 }
 
 func TestDescribeControlDirSync(t *testing.T) {
-	runAddControlDescriptions(t, NewControlDirSyncForEncode(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
+	runAddControlDescriptions(t, NewRequestControlDirSync(DirSyncObjectSecurity, 1000, nil), "Control Type (DirSync)", "Criticality", "Control Value")
 }
 
 func runAddControlDescriptions(t *testing.T, originalControl Control, childDescriptions ...string) {

--- a/v3/search.go
+++ b/v3/search.go
@@ -635,55 +635,56 @@ func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
 }
 
 // DirSync does a Search with dirSync Control.
-func (l *Conn) DirSync(searchRequest *SearchRequest, flags int64, maxAttrCount int64, cookie []byte) (*SearchResult, error) {
-	var dirSyncControl *ControlDirSync
-
+func (l *Conn) DirSync(
+	searchRequest *SearchRequest, flags int64, maxAttrCount int64, cookie []byte,
+) (*SearchResult, error) {
 	control := FindControl(searchRequest.Controls, ControlTypeDirSync)
 	if control == nil {
-		dirSyncControl = NewControlDirSync(flags, maxAttrCount, cookie)
-		searchRequest.Controls = append(searchRequest.Controls, dirSyncControl)
+		c := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+		searchRequest.Controls = append(searchRequest.Controls, c)
 	} else {
-		castControl, ok := control.(*ControlDirSync)
-		if !ok {
-			return nil, fmt.Errorf("Expected DirSync control to be of type *ControlDirSync, got %v", control)
+		c := control.(*ControlDirSync)
+		if c.Flags != flags {
+			return nil, fmt.Errorf("flags given in search request (%d) conflicts with flags given in search call (%d)", c.Flags, flags)
 		}
-		if castControl.Flags != flags {
-			return nil, fmt.Errorf("flags given in search request (%d) conflicts with flags given in search call (%d)", castControl.Flags, flags)
+		if c.MaxAttrCount != maxAttrCount {
+			return nil, fmt.Errorf("MaxAttrCnt given in search request (%d) conflicts with maxAttrCount given in search call (%d)", c.MaxAttrCount, maxAttrCount)
 		}
-		if castControl.MaxAttrCnt != maxAttrCount {
-			return nil, fmt.Errorf("MaxAttrCnt given in search request (%d) conflicts with maxAttrCount given in search call (%d)", castControl.MaxAttrCnt, maxAttrCount)
-		}
-		dirSyncControl = castControl
 	}
-	searchResult := new(SearchResult)
-	result, err := l.Search(searchRequest)
+	searchResult, err := l.Search(searchRequest)
 	l.Debug.Printf("Looking for result...")
 	if err != nil {
-		return searchResult, err
+		return nil, err
 	}
-	if result == nil {
-		return searchResult, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
+	if searchResult == nil {
+		return nil, NewError(ErrorNetwork, errors.New("ldap: packet not received"))
 	}
-
-	searchResult.Entries = append(searchResult.Entries, result.Entries...)
-	searchResult.Referrals = append(searchResult.Referrals, result.Referrals...)
-	searchResult.Controls = append(searchResult.Controls, result.Controls...)
 
 	l.Debug.Printf("Looking for DirSync Control...")
-	dirSyncResult := FindControl(result.Controls, ControlTypeDirSync)
-	if dirSyncResult == nil {
-		dirSyncControl = nil
+	resultControl := FindControl(searchResult.Controls, ControlTypeDirSync)
+	if resultControl == nil {
 		l.Debug.Printf("Could not find dirSyncControl control.  Breaking...")
 		return searchResult, nil
 	}
 
-	cookie = dirSyncResult.(*ControlDirSync).Cookie
+	cookie = resultControl.(*ControlDirSync).Cookie
 	if len(cookie) == 0 {
-		dirSyncControl = nil
 		l.Debug.Printf("Could not find cookie.  Breaking...")
 		return searchResult, nil
 	}
-	dirSyncControl.SetCookie(cookie)
 
 	return searchResult, nil
+}
+
+// DirSyncDirSyncAsync performs a search request and returns all search results
+// asynchronously. This is efficient when the server returns lots of entries.
+func (l *Conn) DirSyncAsync(
+	ctx context.Context, searchRequest *SearchRequest, bufferSize int,
+	flags, maxAttrCount int64, cookie []byte,
+) Response {
+	control := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+	searchRequest.Controls = append(searchRequest.Controls, control)
+	r := newSearchResponse(l, bufferSize)
+	r.start(ctx, searchRequest)
+	return r
 }

--- a/v3/search.go
+++ b/v3/search.go
@@ -640,7 +640,7 @@ func (l *Conn) DirSync(
 ) (*SearchResult, error) {
 	control := FindControl(searchRequest.Controls, ControlTypeDirSync)
 	if control == nil {
-		c := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+		c := NewRequestControlDirSync(flags, maxAttrCount, cookie)
 		searchRequest.Controls = append(searchRequest.Controls, c)
 	} else {
 		c := control.(*ControlDirSync)
@@ -682,7 +682,7 @@ func (l *Conn) DirSyncAsync(
 	ctx context.Context, searchRequest *SearchRequest, bufferSize int,
 	flags, maxAttrCount int64, cookie []byte,
 ) Response {
-	control := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
+	control := NewRequestControlDirSync(flags, maxAttrCount, cookie)
 	searchRequest.Controls = append(searchRequest.Controls, control)
 	r := newSearchResponse(l, bufferSize)
 	r.start(ctx, searchRequest)


### PR DESCRIPTION
I'm now developing an application to connect the Windows AD server and get entries. Thanks to #436, I can use DirSync() method to search. As my requirement, I have to handle several ten thousand entries. This is not so big, but waste of memory at once. I noticed #440 provides a search asynchronous feature, so I can search without getting all entries at once.

I looked into the code in DirSync() method and tested it. I refactored some minor changes for maintainability.

## About DirSyncAsync() method

I made it as below. It works in my environment.

```go
// DirSyncDirSyncAsync performs a search request and returns all search results
// asynchronously. This is efficient when the server returns lots of entries.
func (l *Conn) DirSyncAsync(
	ctx context.Context, searchRequest *SearchRequest, bufferSize int,
	flags, maxAttrCount int64, cookie []byte,
) Response {
	control := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
	searchRequest.Controls = append(searchRequest.Controls, control)
	r := newSearchResponse(l, bufferSize)
	r.start(ctx, searchRequest)
	return r
}
```

However, I can implement this by myself like this. So, what do you think about whether we provide this short-cut helper or not?  I made this to confirm dirsync search works with asynchronous, so DirSyncAsync() method is not important for me.

```go
control := NewControlDirSyncForEncode(flags, maxAttrCount, cookie)
searchRequest.Controls = append(searchRequest.Controls, control)
r := SearchAsync(ctx, searchRequest, 64)
```