### PR TITLE
Add support for Go 1.13's errors.Is/As functions

### DIFF
--- a/v3/error.go
+++ b/v3/error.go
@@ -192,6 +192,8 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("LDAP Result Code %d %q: %s", e.ResultCode, LDAPResultCodeMap[e.ResultCode], e.Err.Error())
 }
 
+func (e *Error) Unwrap() error { return e.Err }
+
 // GetLDAPError creates an Error out of a BER packet representing a LDAPResult
 // The return is an error object. It can be casted to a Error structure.
 // This function returns nil if resultCode in the LDAPResult sequence is success(0).

--- a/v3/error_test.go
+++ b/v3/error_test.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"errors"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -100,6 +101,24 @@ func TestGetLDAPErrorInvalidResponse(t *testing.T) {
 	ldapError := err.(*Error)
 	if ldapError.ResultCode != ErrorNetwork {
 		t.Errorf("Got incorrect error code in LDAP error; got %v, expected %v", ldapError.ResultCode, ErrorNetwork)
+	}
+}
+
+func TestErrorIs(t *testing.T) {
+	err := NewError(ErrorNetwork, io.EOF)
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("Expected an io.EOF error: %v", err)
+	}
+}
+
+func TestErrorAs(t *testing.T) {
+	var netErr net.InvalidAddrError = "invalid addr"
+	err := NewError(ErrorNetwork, netErr)
+
+	var target net.InvalidAddrError
+	ok := errors.As(err, &target)
+	if !ok {
+		t.Error("Expected an InvalidAddrError")
 	}
 }
 


### PR DESCRIPTION
ldap.Error wraps an underlying error, but doesn't interoperate with errors.Is or errors.As. This change makes it easier to detect things like an LDAP error caused due to a network timeout.