### PR TITLE
IsErrorAnyOf should match the given result code even if the error is wrapped

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
@@ -241,8 +242,8 @@ func IsErrorAnyOf(err error, codes ...uint16) bool {
 		return false
 	}
 
-	serverError, ok := err.(*Error)
-	if !ok {
+	var serverError *Error
+	if !errors.As(err, &serverError) {
 		return false
 	}
 

--- a/v3/error.go
+++ b/v3/error.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"errors"
 	"fmt"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
@@ -241,8 +242,8 @@ func IsErrorAnyOf(err error, codes ...uint16) bool {
 		return false
 	}
 
-	serverError, ok := err.(*Error)
-	if !ok {
+	var serverError *Error
+	if !errors.As(err, &serverError) {
 		return false
 	}
 


### PR DESCRIPTION
This might break compatibility, but I guess that most developers want this behavior. What do you think?