### PR TITLE
Fix DATA RACE as a result of changing ber's module global variable for fuzz tests

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -4,15 +4,23 @@
 package ldap
 
 import (
-	ber "github.com/go-asn1-ber/asn1-ber"
+	"os"
 	"testing"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
-func FuzzParseDN(f *testing.F) {
+func TestMain(m *testing.M) {
+	// For fuzz tests
 	// See https://github.com/go-asn1-ber/asn1-ber/blob/04301b4b1c5ff66221f8f8a394f814a9917d678a/fuzz_test.go#L33-L37
 	// for why this limitation is necessary
 	ber.MaxPacketLengthBytes = 65536
 
+	code := m.Run()
+	os.Exit(code)
+}
+
+func FuzzParseDN(f *testing.F) {
 	f.Add("*")
 	f.Add("cn=Jim\\0Test")
 	f.Add("cn=Jim\\0")


### PR DESCRIPTION
I investigated why DATA RACE occurred.

```
WARNING: DATA RACE
Write at 0x000000c3c628 by goroutine 38:
  github.com/go-ldap/ldap.FuzzParseDN()
      /home/runner/work/ldap/ldap/fuzz_test.go:14 +0x32
  testing.fRunner()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/fuzz.go:700 +0x168
  testing.runFuzzTests.func1()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/fuzz.go:5[20](https://github.com/go-ldap/ldap/actions/runs/6781841980/job/18432888679#step:5:21) +0x47
```

Fuzz tests also run as unit tests, so the module global variable shouldn't change in a test function.

```go
ber.MaxPacketLengthBytes = 65536
```

I fix this conflict by adding TestMain(), which handles a setup process before all tests. Now, all tests run with `ber.MaxPacketLengthBytes` limitation. Does it make sense?

See also #472.

## References

* https://go.dev/security/fuzz/