### PR TITLE
Fix deprecated warning on GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.0
           only-new-issues: true


### PR DESCRIPTION
I found a deprecated warning on Annotations.

* https://github.com/go-ldap/ldap/actions/runs/6924243142

> Lint
> 
> The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This warning is from the old core library in golangci-lint-action. So, update it.

## Reference

* https://github.com/golangci/golangci-lint-action/pull/578