### PR TITLE
feat: extend SearchResult `Unmarshal` to support *string as field type (#475)

### DIFF
--- a/search.go
+++ b/search.go
@@ -279,6 +279,8 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 			}
 		case string:
 			fv.SetString(values[0])
+		case *string:
+			fv.Set(reflect.ValueOf(&values[0]))
 		case []byte:
 			fv.SetBytes([]byte(values[0]))
 		case int, int64:

--- a/search.go
+++ b/search.go
@@ -187,8 +187,8 @@ func readTag(f reflect.StructField) (string, bool) {
 // Unmarshal parses the Entry in the value pointed to by i
 //
 // Currently, this methods only supports struct fields of type
-// string, []string, int, int64, []byte, *DN, []*DN or time.Time. Other field types
-// will not be regarded. If the field type is a string or int but multiple
+// string, *string, []string, int, int64, []byte, *DN, []*DN or time.Time.
+// Other field types will not be regarded. If the field type is a string or int but multiple
 // attribute values are returned, the first value will be used to fill the field.
 //
 // Example:
@@ -310,7 +310,7 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 				fv.Set(reflect.Append(fv, reflect.ValueOf(dn)))
 			}
 		default:
-			return fmt.Errorf("ldap: expected field to be of type string, []string, int, int64, []byte, *DN, []*DN or time.Time, got %v", ft.Type)
+			return fmt.Errorf("ldap: expected field to be of type string, *string, []string, int, int64, []byte, *DN, []*DN or time.Time, got %v", ft.Type)
 		}
 	}
 	return

--- a/search_test.go
+++ b/search_test.go
@@ -87,6 +87,11 @@ func TestEntry_Unmarshal(t *testing.T) {
 					Values:     []string{"mario@go-ldap.com"},
 					ByteValues: nil,
 				},
+				{
+					Name:       "upn",
+					Values:     []string{"mario@go-ldap.com.domain"},
+					ByteValues: nil,
+				},
 				// Tests int value.
 				{
 					Name:       "id",
@@ -132,6 +137,7 @@ func TestEntry_Unmarshal(t *testing.T) {
 			Dn       string    `ldap:"dn"`
 			Cn       string    `ldap:"cn"`
 			Mail     string    `ldap:"mail"`
+			UPN      *string   `ldap:"upn"`
 			ID       int       `ldap:"id"`
 			LongID   int64     `ldap:"longId"`
 			Data     []byte    `ldap:"data"`
@@ -157,10 +163,12 @@ func TestEntry_Unmarshal(t *testing.T) {
 			children = append(children, dn)
 		}
 
+		UPN := "mario@go-ldap.com.domain"
 		expect := &User{
 			Dn:       "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
 			Cn:       "mario",
 			Mail:     "mario@go-ldap.com",
+			UPN:      &UPN,
 			ID:       2147483647,
 			LongID:   9223372036854775807,
 			Data:     []byte("data"),

--- a/v3/search.go
+++ b/v3/search.go
@@ -279,6 +279,8 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 			}
 		case string:
 			fv.SetString(values[0])
+		case *string:
+			fv.Set(reflect.ValueOf(&values[0]))
 		case []byte:
 			fv.SetBytes([]byte(values[0]))
 		case int, int64:

--- a/v3/search.go
+++ b/v3/search.go
@@ -187,8 +187,8 @@ func readTag(f reflect.StructField) (string, bool) {
 // Unmarshal parses the Entry in the value pointed to by i
 //
 // Currently, this methods only supports struct fields of type
-// string, []string, int, int64, []byte, *DN, []*DN or time.Time. Other field types
-// will not be regarded. If the field type is a string or int but multiple
+// string, *string, []string, int, int64, []byte, *DN, []*DN or time.Time.
+// Other field types will not be regarded. If the field type is a string or int but multiple
 // attribute values are returned, the first value will be used to fill the field.
 //
 // Example:
@@ -310,7 +310,7 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 				fv.Set(reflect.Append(fv, reflect.ValueOf(dn)))
 			}
 		default:
-			return fmt.Errorf("ldap: expected field to be of type string, []string, int, int64, []byte, *DN, []*DN or time.Time, got %v", ft.Type)
+			return fmt.Errorf("ldap: expected field to be of type string, *string, []string, int, int64, []byte, *DN, []*DN or time.Time, got %v", ft.Type)
 		}
 	}
 	return

--- a/v3/search_test.go
+++ b/v3/search_test.go
@@ -87,6 +87,11 @@ func TestEntry_Unmarshal(t *testing.T) {
 					Values:     []string{"mario@go-ldap.com"},
 					ByteValues: nil,
 				},
+				{
+					Name:       "upn",
+					Values:     []string{"mario@go-ldap.com.domain"},
+					ByteValues: nil,
+				},
 				// Tests int value.
 				{
 					Name:       "id",
@@ -132,6 +137,7 @@ func TestEntry_Unmarshal(t *testing.T) {
 			Dn       string    `ldap:"dn"`
 			Cn       string    `ldap:"cn"`
 			Mail     string    `ldap:"mail"`
+			UPN      *string   `ldap:"upn"`
 			ID       int       `ldap:"id"`
 			LongID   int64     `ldap:"longId"`
 			Data     []byte    `ldap:"data"`
@@ -157,10 +163,12 @@ func TestEntry_Unmarshal(t *testing.T) {
 			children = append(children, dn)
 		}
 
+		UPN := "mario@go-ldap.com.domain"
 		expect := &User{
 			Dn:       "cn=mario,ou=Users,dc=go-ldap,dc=github,dc=com",
 			Cn:       "mario",
 			Mail:     "mario@go-ldap.com",
+			UPN:      &UPN,
 			ID:       2147483647,
 			LongID:   9223372036854775807,
 			Data:     []byte("data"),


### PR DESCRIPTION
This PR adds `*string` as available type for `SearchResult.Unmarshal`. Closes #475