### PR TITLE
Refactor the context handling with receiving an ldap response in searchAsync()

### DIFF
--- a/response.go
+++ b/response.go
@@ -102,9 +102,7 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 			case <-ctx.Done():
 				r.conn.Debug.Printf("%d: %s", msgCtx.id, ctx.Err().Error())
 				return
-			default:
-				r.conn.Debug.Printf("%d: waiting for response", msgCtx.id)
-				packetResponse, ok := <-msgCtx.responses
+			case packetResponse, ok := <-msgCtx.responses:
 				if !ok {
 					err := NewError(ErrorNetwork, errors.New("ldap: response channel closed"))
 					r.ch <- &SearchSingleResult{Error: err}

--- a/response.go
+++ b/response.go
@@ -98,6 +98,7 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 
 		foundSearchSingleResultDone := false
 		for !foundSearchSingleResultDone {
+			r.conn.Debug.Printf("%d: waiting for response", msgCtx.id)
 			select {
 			case <-ctx.Done():
 				r.conn.Debug.Printf("%d: %s", msgCtx.id, ctx.Err().Error())

--- a/v3/response.go
+++ b/v3/response.go
@@ -102,9 +102,7 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 			case <-ctx.Done():
 				r.conn.Debug.Printf("%d: %s", msgCtx.id, ctx.Err().Error())
 				return
-			default:
-				r.conn.Debug.Printf("%d: waiting for response", msgCtx.id)
-				packetResponse, ok := <-msgCtx.responses
+			case packetResponse, ok := <-msgCtx.responses:
 				if !ok {
 					err := NewError(ErrorNetwork, errors.New("ldap: response channel closed"))
 					r.ch <- &SearchSingleResult{Error: err}

--- a/v3/response.go
+++ b/v3/response.go
@@ -98,6 +98,7 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 
 		foundSearchSingleResultDone := false
 		for !foundSearchSingleResultDone {
+			r.conn.Debug.Printf("%d: waiting for response", msgCtx.id)
 			select {
 			case <-ctx.Done():
 				r.conn.Debug.Printf("%d: %s", msgCtx.id, ctx.Err().Error())


### PR DESCRIPTION
@SaschaRoland suggested refactoring context handling in #495. This change enables context-based canceling while receiving an LDAP response.