### PR TITLE
Revert "fix: Limit maximum BER packet length in `FuzzParseDN` to 6553…

### DIFF
--- a/dn.go
+++ b/dn.go
@@ -149,7 +149,7 @@ func (d *DN) String() string {
 func decodeString(str string) (string, error) {
 	s := []rune(strings.TrimSpace(str))
 	// Re-add the trailing space if the last character was an escaped space character
-	if len(s) > 0 && s[len(s)-1] == '\\' && str[len(str)-2] == ' ' {
+	if len(s) > 0 && s[len(s)-1] == '\\' && str[len(str)-1] == ' ' {
 		s = append(s, ' ')
 	}
 
@@ -234,7 +234,7 @@ func decodeEncodedString(str string) (string, error) {
 // The function respects https://tools.ietf.org/html/rfc4514
 func ParseDN(str string) (*DN, error) {
 	var dn = &DN{RDNs: make([]*RelativeDN, 0)}
-	if str = strings.TrimSpace(str); len(str) == 0 {
+	if strings.TrimSpace(str) == "" {
 		return dn, nil
 	}
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -3,22 +3,7 @@
 
 package ldap
 
-import (
-	"os"
-	"testing"
-
-	ber "github.com/go-asn1-ber/asn1-ber"
-)
-
-func TestMain(m *testing.M) {
-	// For fuzz tests
-	// See https://github.com/go-asn1-ber/asn1-ber/blob/04301b4b1c5ff66221f8f8a394f814a9917d678a/fuzz_test.go#L33-L37
-	// for why this limitation is necessary
-	ber.MaxPacketLengthBytes = 65536
-
-	code := m.Run()
-	os.Exit(code)
-}
+import "testing"
 
 func FuzzParseDN(f *testing.F) {
 	f.Add("*")
@@ -33,7 +18,6 @@ func FuzzParseDN(f *testing.F) {
 }
 
 func FuzzDecodeEscapedSymbols(f *testing.F) {
-
 	f.Add([]byte("a\u0100\x80"))
 	f.Add([]byte(`start\d`))
 	f.Add([]byte(`\`))
@@ -46,7 +30,6 @@ func FuzzDecodeEscapedSymbols(f *testing.F) {
 }
 
 func FuzzEscapeDN(f *testing.F) {
-
 	f.Add("test,user")
 	f.Add("#test#user#")
 	f.Add("\\test\\user\\")

--- a/v3/dn.go
+++ b/v3/dn.go
@@ -149,7 +149,7 @@ func (d *DN) String() string {
 func decodeString(str string) (string, error) {
 	s := []rune(strings.TrimSpace(str))
 	// Re-add the trailing space if the last character was an escaped space character
-	if len(s) > 0 && s[len(s)-1] == '\\' && str[len(str)-2] == ' ' {
+	if len(s) > 0 && s[len(s)-1] == '\\' && str[len(str)-1] == ' ' {
 		s = append(s, ' ')
 	}
 
@@ -234,7 +234,7 @@ func decodeEncodedString(str string) (string, error) {
 // The function respects https://tools.ietf.org/html/rfc4514
 func ParseDN(str string) (*DN, error) {
 	var dn = &DN{RDNs: make([]*RelativeDN, 0)}
-	if str = strings.TrimSpace(str); len(str) == 0 {
+	if strings.TrimSpace(str) == "" {
 		return dn, nil
 	}
 


### PR DESCRIPTION
This reverts commit 80095a39 and removes the ASN1 BER memory  limitation during fuzzing, since `ParseDN` has been refactored in ff74b2c561b23d0797d635e132de25d30157917a (#497).