### PR TITLE
fix: Replace DER with ASN1 BER encoding when parsing distinguishedNames

### DIFF
--- a/dn.go
+++ b/dn.go
@@ -35,9 +35,6 @@ func (a *AttributeTypeAndValue) setValue(s string) error {
 	// AttributeValue is represented by an number sign ('#' U+0023)
 	// character followed by the hexadecimal encoding of each of the octets
 	// of the BER encoding of the X.500 AttributeValue.
-	//
-	// WARNING: we only support hex-encoded ASN.1 DER values here, not
-	// BER encoding. This is a deviation from the RFC.
 	if len(s) > 0 && s[0] == '#' {
 		decodedString, err := decodeEncodedString(s[1:])
 		if err != nil {

--- a/dn.go
+++ b/dn.go
@@ -1,10 +1,10 @@
 package ldap
 
 import (
-	"encoding/asn1"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"sort"
 	"strings"
 	"unicode"
@@ -233,19 +233,15 @@ func encodeString(value string, isValue bool) string {
 func decodeEncodedString(str string) (string, error) {
 	decoded, err := hex.DecodeString(str)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode BER encoding: %s", err)
+		return "", fmt.Errorf("failed to decode BER encoding: %w", err)
 	}
 
-	var rawValue asn1.RawValue
-	result, err := asn1.Unmarshal(decoded, &rawValue)
+	packet, err := ber.DecodePacketErr(decoded)
 	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal hex-encoded string: %s", err)
-	}
-	if len(result) != 0 {
-		return "", errors.New("trailing data after unmarshalling hex-encoded string")
+		return "", fmt.Errorf("failed to decode BER encoding: %w", err)
 	}
 
-	return string(rawValue.Bytes), nil
+	return packet.Data.String(), nil
 }
 
 // ParseDN returns a distinguishedName or an error.

--- a/dn_test.go
+++ b/dn_test.go
@@ -154,7 +154,7 @@ func TestErrorDNParsing(t *testing.T) {
 		"1.3.6.1.4.1.1466.0=test+":  "DN ended with incomplete type, value pair",
 		`1.3.6.1.4.1.1466.0=test;`:  "DN ended with incomplete type, value pair",
 		"1.3.6.1.4.1.1466.0=test+,": "incomplete type, value pair",
-		"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF": "failed to unmarshal hex-encoded string: asn1: syntax error: data truncated",
+		"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF": "failed to decode BER encoding: unexpected EOF",
 	}
 
 	for test, answer := range testcases {

--- a/v3/dn.go
+++ b/v3/dn.go
@@ -35,9 +35,6 @@ func (a *AttributeTypeAndValue) setValue(s string) error {
 	// AttributeValue is represented by an number sign ('#' U+0023)
 	// character followed by the hexadecimal encoding of each of the octets
 	// of the BER encoding of the X.500 AttributeValue.
-	//
-	// WARNING: we only support hex-encoded ASN.1 DER values here, not
-	// BER encoding. This is a deviation from the RFC.
 	if len(s) > 0 && s[0] == '#' {
 		decodedString, err := decodeEncodedString(s[1:])
 		if err != nil {

--- a/v3/dn.go
+++ b/v3/dn.go
@@ -1,10 +1,10 @@
 package ldap
 
 import (
-	"encoding/asn1"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"sort"
 	"strings"
 	"unicode"
@@ -233,19 +233,15 @@ func encodeString(value string, isValue bool) string {
 func decodeEncodedString(str string) (string, error) {
 	decoded, err := hex.DecodeString(str)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode BER encoding: %s", err)
+		return "", fmt.Errorf("failed to decode BER encoding: %w", err)
 	}
 
-	var rawValue asn1.RawValue
-	result, err := asn1.Unmarshal(decoded, &rawValue)
+	packet, err := ber.DecodePacketErr(decoded)
 	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal hex-encoded string: %s", err)
-	}
-	if len(result) != 0 {
-		return "", errors.New("trailing data after unmarshalling hex-encoded string")
+		return "", fmt.Errorf("failed to decode BER encoding: %w", err)
 	}
 
-	return string(rawValue.Bytes), nil
+	return packet.Data.String(), nil
 }
 
 // ParseDN returns a distinguishedName or an error.

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -154,7 +154,7 @@ func TestErrorDNParsing(t *testing.T) {
 		"1.3.6.1.4.1.1466.0=test+":  "DN ended with incomplete type, value pair",
 		`1.3.6.1.4.1.1466.0=test;`:  "DN ended with incomplete type, value pair",
 		"1.3.6.1.4.1.1466.0=test+,": "incomplete type, value pair",
-		"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF": "failed to unmarshal hex-encoded string: asn1: syntax error: data truncated",
+		"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF": "failed to decode BER encoding: unexpected EOF",
 	}
 
 	for test, answer := range testcases {


### PR DESCRIPTION
This PR replaces the Go asn1 library in the `decodeEncodedString` function to decode values with ASN1 BER instead. The replacement of the returned error should be ok, as there hasn't been a release with the new implementation of `ParseDN' yet.

See  [RFC4514 Section 2.4](https://www.ietf.org/rfc/rfc4514.html#section-2.4):
> If the AttributeType is of the dotted-decimal form, the
   AttributeValue is represented by an number sign ('#' U+0023)
   character followed by the hexadecimal encoding of each of the octets
   of the BER encoding of the X.500 AttributeValue.  This form is also
   used when the syntax of the AttributeValue does not have an LDAP-
   specific ([[RFC4517], Section 3.1](https://www.ietf.org/rfc/rfc4517#section-3.1)) string encoding defined for it, or
   the LDAP-specific string encoding is not restricted to UTF-8-encoded
   Unicode characters.  This form may also be used in other cases, such
   as when a reversible string representation is desired (see [Section](https://www.ietf.org/rfc/rfc4514.html#section-5.2)
   [5.2](https://www.ietf.org/rfc/rfc4514.html#section-5.2)).