### PR TITLE
Revert #499: Mark public Start function as deprecated

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -265,7 +265,11 @@ func NewConn(conn net.Conn, isTLS bool) *Conn {
 	return l
 }
 
-// Start initializes goroutines to read responses and process messages
+// Start initialises goroutines to read replies and process messages.
+// Warning: Calling this function in addition to Dial or DialURL
+// may cause race conditions.
+//
+// See: https://github.com/go-ldap/ldap/issues/356
 func (l *Conn) Start() {
 	go l.reader()
 	go l.processMessages()

--- a/conn.go
+++ b/conn.go
@@ -265,12 +265,7 @@ func NewConn(conn net.Conn, isTLS bool) *Conn {
 	return l
 }
 
-// Start initialises goroutines to read replies and process messages.
-//
-// Deprecated: It is usually not necessary to call this function
-// manually. It is public for compatibility reasons and may
-// cause a race condition when processing messages.
-// See: https://github.com/go-ldap/ldap/issues/356
+// Start initializes goroutines to read responses and process messages
 func (l *Conn) Start() {
 	go l.reader()
 	go l.processMessages()

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -265,7 +265,11 @@ func NewConn(conn net.Conn, isTLS bool) *Conn {
 	return l
 }
 
-// Start initializes goroutines to read responses and process messages
+// Start initialises goroutines to read replies and process messages.
+// Warning: Calling this function in addition to Dial or DialURL
+// may cause race conditions.
+//
+// See: https://github.com/go-ldap/ldap/issues/356
 func (l *Conn) Start() {
 	go l.reader()
 	go l.processMessages()

--- a/v3/conn.go
+++ b/v3/conn.go
@@ -265,12 +265,7 @@ func NewConn(conn net.Conn, isTLS bool) *Conn {
 	return l
 }
 
-// Start initialises goroutines to read replies and process messages.
-//
-// Deprecated: It is usually not necessary to call this function
-// manually. It is public for compatibility reasons and may
-// cause a race condition when processing messages.
-// See: https://github.com/go-ldap/ldap/issues/356
+// Start initializes goroutines to read responses and process messages
 func (l *Conn) Start() {
 	go l.reader()
 	go l.processMessages()


### PR DESCRIPTION
This reverts the the prematurely deprecation of the `Start` function, because some requirements cannot be implemented via the DialOpts (see #507). This PR reverts this, but adds a warning because of the original intention (see #356)