### PR TITLE
Allow users to specify a custom NTLM negotiator

### DIFF
--- a/v3/bind.go
+++ b/v3/bind.go
@@ -433,12 +433,12 @@ func (req *NTLMBindRequest) appendTo(envelope *ber.Packet) (err error) {
 	case req.Negotiator == nil:
 		negMessage, err = ntlmssp.NewNegotiateMessage(req.Domain, "")
 		if err != nil {
-			return fmt.Errorf("negotiate: %s", err)
+			return fmt.Errorf("create NTLM negotiate message: %s", err)
 		}
 	default:
 		negMessage, err = req.Negotiator.Negotiate(req.Domain, "")
 		if err != nil {
-			return fmt.Errorf("negotiate: %s", err)
+			return fmt.Errorf("create NTLM negotiate message with custom negotiator: %s", err)
 		}
 	}
 
@@ -557,8 +557,9 @@ func (l *Conn) NTLMChallengeBind(ntlmBindRequest *NTLMBindRequest) (*NTLMBindRes
 		}
 
 		if err != nil {
-			return result, fmt.Errorf("parsing ntlm-challenge: %s", err)
+			return result, fmt.Errorf("process NTLM challenge: %s", err)
 		}
+
 		packet = ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Request")
 		packet.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, l.nextMessageID(), "MessageID"))
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/crypto v0.31.0
 	golang.org/x/net v0.33.0 // indirect
 )


### PR DESCRIPTION
This PR adds the `Negotiator` field to `NTLMBindRequest` which lets users specify a custom NTLM implementation. This is needed because `github.com/Azure/go-ntlmssp` is a very limited NTLM implementation with no support for features such as channel binding which may be required to connect to AD LDAP.