### PR TITLE
feat: add initial support for custom entry unmarshaler

### DIFF
--- a/v3/search.go
+++ b/v3/search.go
@@ -305,6 +305,8 @@ func (e *Entry) Unmarshal(i interface{}) (err error) {
 	})
 }
 
+// UnmarshalFunc allows you to define a custom unmarshaler to parse an Entry values. 
+// A custom unmarshaler can be found in the Unmarshal function or in the test files.
 func (e *Entry) UnmarshalFunc(i interface{},
 	fn func(entry *Entry, fieldType reflect.StructField, fieldValue reflect.Value) error) error {
 	// Make sure it's a ptr


### PR DESCRIPTION
As requested in #530, this is rather simple but hopefully straightforward implementation for a custom entry unmarshal function.  This should enable users to create their own Unmarshaler for search results if, for example, special handling of the attribute tags is required