### PR TITLE
[enhancement] Added missing LDAP control ControlMicrosoftSDFlags to control.go

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -444,6 +444,42 @@ func NewControlMicrosoftNotification() *ControlMicrosoftNotification {
 	return &ControlMicrosoftNotification{}
 }
 
+type ControlMicrosoftSDFlags struct {
+	Criticality  bool
+	ControlValue int32
+}
+
+func (c *ControlMicrosoftSDFlags) GetControlType() string {
+	// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3888c2b7-35b9-45b7-afeb-b772aa932dd0
+	return ControlTypeMicrosoftSDFlags
+}
+
+func (c *ControlMicrosoftSDFlags) Encode() *ber.Packet {
+	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	packet.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypeMicrosoftSDFlags, "Control Type ("+ControlTypeMap[ControlTypeMicrosoftSDFlags]+")"))
+	if c.Criticality {
+		packet.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, c.Criticality, "Criticality"))
+	}
+	p2 := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value(SDFlags)")
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "SDFlags")
+	seq.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, c.ControlValue, "Flags"))
+	p2.AppendChild(seq)
+	packet.AppendChild(p2)
+	return packet
+}
+
+func (c *ControlMicrosoftSDFlags) String() string {
+	return fmt.Sprintf(
+		"Control Type: %s (%q)",
+		ControlTypeMap[ControlTypeMicrosoftSDFlags],
+		ControlTypeMicrosoftSDFlags)
+}
+
+// NewControlMicrosoftSDFlags returns a ControlMicrosoftSDFlags control
+func NewControlMicrosoftSDFlags() *ControlMicrosoftSDFlags {
+	return &ControlMicrosoftSDFlags{}
+}
+
 // ControlMicrosoftShowDeleted implements the control described in https://msdn.microsoft.com/en-us/library/aa366989(v=vs.85).aspx
 type ControlMicrosoftShowDeleted struct{}
 


### PR DESCRIPTION
Hi,

I have added a new structure for the LDAP_SERVER_SD_FLAGS_OID control structure that allows to query security descriptors on Windows. Otherwise, as this was brought to me by a colleague, they are not returned in the results of the LDAP query (only empty values).

https://stackoverflow.com/questions/40771503/selecting-the-ad-ntsecuritydescriptor-attribute-as-a-non-admin/40773088#40773088

Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3888c2b7-35b9-45b7-afeb-b772aa932dd0

In the future, wouldn't that be nice to have a `controls/` submodule containing one file per control structure as well as a global file containing all the OIDs? This would make the codebase more readable in my opinion. What do you think @cpuschma?
If you agree I volunteer to do this for the Microsoft Controls :)

Best regards,