### PR TITLE
Add RFC 5929 channel binding support for SSPI client

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
-	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa
+	github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667
 	github.com/google/uuid v1.6.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
+github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/v3/gssapi/sspi_test.go
+++ b/v3/gssapi/sspi_test.go
@@ -1,0 +1,108 @@
+//go:build windows
+// +build windows
+
+package gssapi
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+// createTestCertificate creates a test certificate with the specified signature algorithm.
+func createTestCertificate(sigAlg x509.SignatureAlgorithm) (*x509.Certificate, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	template := x509.Certificate{
+		SignatureAlgorithm: sigAlg,
+		SerialNumber:       big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Company"},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{"San Francisco"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert, nil
+}
+
+func TestNewSSPIClientWithChannelBinding(t *testing.T) {
+	tests := []struct {
+		name   string
+		sigAlg x509.SignatureAlgorithm
+	}{
+		{
+			name:   x509.SHA256WithRSA.String(),
+			sigAlg: x509.SHA256WithRSA,
+		},
+		{
+			name:   x509.SHA384WithRSA.String(),
+			sigAlg: x509.SHA384WithRSA,
+		},
+		{
+			name:   x509.SHA512WithRSA.String(),
+			sigAlg: x509.SHA512WithRSA,
+		},
+		{
+			name:   x509.SHA1WithRSA.String() + " (should fallback to SHA256)",
+			sigAlg: x509.SHA1WithRSA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert, err := createTestCertificate(tt.sigAlg)
+			if err != nil {
+				t.Fatalf("Failed to create test certificate: %v", err)
+			}
+
+			client, err := NewSSPIClientWithChannelBinding(cert)
+			t.Cleanup(func() {
+				client.Close()
+			})
+
+			if err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if client == nil {
+				t.Error("Expected client but got nil")
+			}
+			if len(client.channelBindings) == 0 {
+				t.Error("Expected channel bindings to be set")
+			}
+
+			applicationData := client.channelBindings[32:]
+			expectedPrefix := "tls-server-end-point:"
+			if !strings.HasPrefix(string(applicationData), expectedPrefix) {
+				t.Errorf("Expected application data to start with %q, got %q", expectedPrefix, string(applicationData))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR relates to: https://github.com/alexbrainman/sspi/pull/18
This PR should also not be merged before above PR is merged since it is strictly dependant on those changes.

In newer microsoft active directory versions, channel binding token is on by default, causing clients to fail to authorize.
These changes gives an option to enable the security context to be updated with a channel binding token.

I have tested manually against active directory servers that have this feature on and off, and after these changes along with above PR, I was able to connect and authorize as usual.

It is hard to write tests for things like this that talks to the operating system, but any pointers to how I can improve my tests would be appreciated, otherwise I hope this us up to the standard of the lib in general.