### PR TITLE
feat: Add local directory server for tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Version
         run: go version
 
+      - name: Setup local directory server
+        run: make local-server
+
       - name: Build, Validate, and Test
         run: |
           cd ${{ matrix.directory }}

--- a/testdata/01_Organizational_Units.ldif
+++ b/testdata/01_Organizational_Units.ldif
@@ -1,0 +1,7 @@
+dn: ou=people,dc=example,dc=com
+objectClass: organizationalUnit
+ou: people
+
+dn: ou=groups,dc=example,dc=com
+objectClass: organizationalUnit
+ou: groups

--- a/testdata/02_Groups.ldif
+++ b/testdata/02_Groups.ldif
@@ -1,0 +1,7 @@
+dn: cn=DistributionList,ou=groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: DistributionList
+member:
+member: cn=DoeJo,ou=people,dc=example,dc=com
+member: cn=MustermannMa,ou=people,dc=example,dc=com

--- a/testdata/02_People.ldif
+++ b/testdata/02_People.ldif
@@ -1,0 +1,21 @@
+dn: cn=DoeJo,ou=people,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: DoeJo
+sn: Doe
+displayName: Doe, John
+givenName: John
+mail: John.Doe@example.com
+
+dn: cn=MustermannMa,ou=people,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: MustermannMa
+sn: Mustermann
+displayName: Mustermann, Max
+givenName: Max
+mail: Max.Mustermann@example.com

--- a/v3/ldap_test.go
+++ b/v3/ldap_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 const (
-	ldapServer  = "ldap://ldap.itd.umich.edu:389"
-	ldapsServer = "ldaps://ldap.itd.umich.edu:636"
-	baseDN      = "dc=umich,dc=edu"
+	ldapServer  = "ldap://127.0.0.1:3389"
+	ldapsServer = "ldaps://127.0.0.1:3636"
+	baseDN      = "dc=example,dc=com"
 )
 
 var filter = []string{
-	"(cn=cis-fac)",
-	"(&(owner=*)(cn=cis-fac))",
-	"(&(objectclass=rfc822mailgroup)(cn=*Computer*))",
-	"(&(objectclass=rfc822mailgroup)(cn=*Mathematics*))",
+	"(cn=DoeJo)",
+	"(&(sn=Doe)(givenName=John))",
+	"(|(sn=Doe)(givenName=Max*))",
+	"(objectClass=inetOrgPerson)",
 }
 
 var attributes = []string{
@@ -258,9 +258,9 @@ func TestCompare(t *testing.T) {
 	}
 	defer l.Close()
 
-	const dn = "cn=math mich,ou=User Groups,ou=Groups,dc=umich,dc=edu"
+	const dn = "cn=DoeJo,ou=people,dc=example,dc=com"
 	const attribute = "cn"
-	const value = "math mich"
+	const value = "DoeJo"
 
 	sr, err := l.Compare(dn, attribute, value)
 	if err != nil {


### PR DESCRIPTION
This PR replaces the previously used directory server "ldap.itd.umich.edu", which went offline a few weeks ago. This PR adds a Makefile command that quickly sets up and provisions a local OpenLDAP server with an example structure.

The data used to scaffold the directory server is located in the testdata folder because I did not want to clutter the Makefile with LDIFs.

It has been tested with both Podman (rootless) and Docker.