### PR TITLE
Fix ExtendedResponse parsing

### DIFF
--- a/v3/extended.go
+++ b/v3/extended.go
@@ -76,15 +76,23 @@ func (l *Conn) Extended(er *ExtendedRequest) (*ExtendedResponse, error) {
 		return nil, err
 	}
 
-	if len(packet.Children[1].Children) < 4 {
+	if len(packet.Children[1].Children) < 3 {
 		return nil, fmt.Errorf(
-			"ldap: malformed extended response: expected 4 children, got %d",
+			"ldap: malformed extended response: expected at least 3 children, got %d",
 			len(packet.Children),
 		)
 	}
 
+	var name string
+
+	if len(packet.Children[1].Children) < 4 {
+		name = er.Name
+	} else {
+		name = packet.Children[1].Children[3].Data.String()
+	}
+
 	response := &ExtendedResponse{
-		Name:     packet.Children[1].Children[3].Data.String(),
+		Name:     name,
 		Controls: make([]Control, 0),
 	}
 


### PR DESCRIPTION
According to rfc4511 `responseName` field in `ExtendedResponse` is `OPTIONAL`.

I hit the problem with number of fields parsing 2.16.840.1.113730.3.8.10.5 response where FreeIPA returns only Controls.