### PR TITLE
refactor: simplify `WhoAmI` implementation using `Extended` API

### DIFF
--- a/v3/whoami.go
+++ b/v3/whoami.go
@@ -4,10 +4,6 @@ package ldap
 //
 // https://tools.ietf.org/html/rfc4532
 
-import (
-	"fmt"
-)
-
 // WhoAmIResult is returned by the WhoAmI() call
 type WhoAmIResult struct {
 	AuthzID string
@@ -21,10 +17,6 @@ func (l *Conn) WhoAmI(controls []Control) (*WhoAmIResult, error) {
 	resp, err := l.Extended(extendedRequest)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.ResultCode != 0 {
-		return nil, NewError(ErrorUnexpectedResponse, fmt.Errorf("Unexpected Response: %d", resp.ResultCode))
 	}
 
 	return &WhoAmIResult{AuthzID: resp.Value.Data.String()}, nil


### PR DESCRIPTION
- Replace custom encoding/decoding logic with `NewExtendedRequest`.
- Streamline result handling by utilizing `Extended` response directly.