### PR TITLE
make stop-local-server fails with Docker due to unsupported -t option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ local-server:
 	@$(CONTAINER_CMD) exec $(CONTAINER_NAME) /bin/sh -c 'for file in /testdata/*.ldif; do echo "Processing $$file..."; cat "$$file" | ldapadd -v -x -H $(LDAP_URL) -D "$(LDAP_ADMIN_DN)" -w $(LDAP_ADMIN_PASSWORD); done'
 
 stop-local-server:
-	-$(CONTAINER_CMD) rm -f -t 10 $(CONTAINER_NAME)
+	-$(CONTAINER_CMD) rm -f $(CONTAINER_NAME)
 
 test:
 	go test -v -cover -race -count=1 .


### PR DESCRIPTION
Running `make stop-local-server` fails when using Docker as the container runtime. The `Makefile` currently calls `docker rm -f -t 10`, but the `-t` (`--time`) flag is not supported by `docker rm`.

```
$ make stop-local-server 
/usr/bin/docker rm -f -t 10 go-ldap-test
unknown shorthand flag: 't' in -t

Usage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]

Run 'docker rm --help' for more information
make: [Makefile:50: stop-local-server] Error 125 (ignored)
```

The `-t` / `--time` flag specifies a stop timeout and exists in `podman rm`, but it is not available in `docker rm`.

- [docker rm reference](https://docs.docker.com/reference/cli/docker/container/rm/)
- [podman rm reference](https://docs.podman.io/en/latest/markdown/podman-rm.1.html)

Since this is a development server, would a graceful shutdown timeout still be necessary? If not, removing the `-t 10` option would make the command compatible with both Docker and Podman.