### PR TITLE
Fix panic on malformed LDAP responses

### DIFF
--- a/v3/add.go
+++ b/v3/add.go
@@ -83,6 +83,9 @@ func (l *Conn) Add(addRequest *AddRequest) error {
 		return err
 	}
 
+	if len(packet.Children) < 2 {
+		return fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
+	}
 	if packet.Children[1].Tag == ApplicationAddResponse {
 		err := GetLDAPError(packet)
 		if err != nil {

--- a/v3/compare.go
+++ b/v3/compare.go
@@ -46,6 +46,9 @@ func (l *Conn) Compare(dn, attribute, value string) (bool, error) {
 		return false, err
 	}
 
+	if len(packet.Children) < 2 {
+		return false, fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
+	}
 	if packet.Children[1].Tag == ApplicationCompareResponse {
 		err := GetLDAPError(packet)
 

--- a/v3/del.go
+++ b/v3/del.go
@@ -52,6 +52,9 @@ func (l *Conn) Del(delRequest *DelRequest) error {
 		return err
 	}
 
+	if len(packet.Children) < 2 {
+		return fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
+	}
 	if packet.Children[1].Tag == ApplicationDelResponse {
 		err := GetLDAPError(packet)
 		if err != nil {

--- a/v3/moddn.go
+++ b/v3/moddn.go
@@ -89,6 +89,9 @@ func (l *Conn) ModifyDN(m *ModifyDNRequest) error {
 		return err
 	}
 
+	if len(packet.Children) < 2 {
+		return fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
+	}
 	if packet.Children[1].Tag == ApplicationModifyDNResponse {
 		err := GetLDAPError(packet)
 		if err != nil {

--- a/v3/modify.go
+++ b/v3/modify.go
@@ -121,6 +121,9 @@ func (l *Conn) Modify(modifyRequest *ModifyRequest) error {
 		return err
 	}
 
+	if len(packet.Children) < 2 {
+		return fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
+	}
 	if packet.Children[1].Tag == ApplicationModifyResponse {
 		err := GetLDAPError(packet)
 		if err != nil {
@@ -157,6 +160,10 @@ func (l *Conn) ModifyWithResult(modifyRequest *ModifyRequest) (*ModifyResult, er
 	packet, err := l.readPacket(msgCtx)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(packet.Children) < 2 {
+		return nil, fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
 	}
 
 	switch packet.Children[1].Tag {

--- a/v3/passwdmodify.go
+++ b/v3/passwdmodify.go
@@ -93,6 +93,9 @@ func (l *Conn) PasswordModify(passwordModifyRequest *PasswordModifyRequest) (*Pa
 
 	result := &PasswordModifyResult{}
 
+	if len(packet.Children) < 2 {
+		return nil, fmt.Errorf("ldap: malformed response: expected at least 2 children, got %d", len(packet.Children))
+	}
 	if packet.Children[1].Tag == ApplicationExtendedResponse {
 		if err = GetLDAPError(packet); err != nil {
 			result.Referral = getReferral(err, packet)


### PR DESCRIPTION
## Problem

Six operations (`Add`, `Del`, `Compare`, `Modify`, `ModifyDN`, `PasswordModify`) access `packet.Children[1]` without bounds checking. A malformed BER response with fewer than 2 children causes a **panic** (`index out of range`).

Issue #453 previously fixed `GetLDAPError` for the same class of bug, but these individual callers were never patched.

Fixes #585

## Solution

Add `len(packet.Children) < 2` guard before accessing `packet.Children[1]` in all seven affected call sites across six files:

- `v3/add.go` — `Add()`
- `v3/del.go` — `Del()`
- `v3/compare.go` — `Compare()`
- `v3/modify.go` — `Modify()` and `ModifyWithResult()`
- `v3/moddn.go` — `ModifyDN()`
- `v3/passwdmodify.go` — `PasswordModify()`

Each now returns a descriptive error (`"ldap: malformed response: expected at least 2 children, got N"`) instead of panicking.

## Testing

The fix is purely defensive — existing tests should pass unchanged. A malformed packet with 0 or 1 children will now return an error instead of crashing.