### PR TITLE
Reject unescaped special characters in DN values per RFC 4514

### DIFF
--- a/v3/dn.go
+++ b/v3/dn.go
@@ -4,11 +4,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	ber "github.com/go-asn1-ber/asn1-ber"
 	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
 )
 
 // AttributeTypeAndValue represents an attributeTypeAndValue from https://tools.ietf.org/html/rfc4514
@@ -116,6 +117,16 @@ func decodeString(str string) (string, error) {
 		// If the character is not an escape character, just add it to the
 		// builder and continue
 		if char != '\\' {
+			// RFC 4514 section 2.4: these characters must appear escaped
+			// (either as "\X" or as "\XX" hex) when present in an AttributeValue.
+			// Reject the raw form here so that callers don't silently accept
+			// input that violates the grammar.
+			switch char {
+			case '"', ';', '<', '>':
+				return "", fmt.Errorf("got unescaped character: '%s'", string(char))
+			case 0:
+				return "", fmt.Errorf("got unescaped NULL character")
+			}
 			builder.WriteRune(char)
 			continue
 		}

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -116,6 +116,86 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			{[]*AttributeTypeAndValue{{"ou", "Baz"}}},
 			{[]*AttributeTypeAndValue{{"o", "C; orp."}, {"c", "US"}}},
 		}},
+
+		// RFC 4514 section 2.4: characters that require escaping in an AttributeValue.
+		// Each character is exercised with both the backslash-escape form (e.g. "\,")
+		// and the hex-escape form (e.g. "\2C"), except for the NULL character (U+0000)
+		// which only has the hex form.
+
+		// U+0020 (SPACE) — only requires escaping at the beginning or end of a value.
+		`cn=\ John Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", " John Doe"}}},
+		}},
+		`cn=John Doe\ `: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John Doe "}}},
+		}},
+		`cn=\20John Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", " John Doe"}}},
+		}},
+		`cn=John Doe\20`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John Doe "}}},
+		}},
+
+		// U+0022 (QUOTATION MARK)
+		`cn=John \"Doe\"`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", `John "Doe"`}}},
+		}},
+		`cn=John \22Doe\22`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", `John "Doe"`}}},
+		}},
+
+		// U+002B (PLUS SIGN)
+		`cn=John\+Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John+Doe"}}},
+		}},
+		`cn=John\2BDoe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John+Doe"}}},
+		}},
+
+		// U+002C (COMMA)
+		`cn=Doe\, John`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "Doe, John"}}},
+		}},
+		`cn=Doe\2C John`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "Doe, John"}}},
+		}},
+
+		// U+003B (SEMICOLON)
+		`cn=John\;Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John;Doe"}}},
+		}},
+		`cn=John\3BDoe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John;Doe"}}},
+		}},
+
+		// U+003C (LESS-THAN SIGN)
+		`cn=John\<Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John<Doe"}}},
+		}},
+		`cn=John\3CDoe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John<Doe"}}},
+		}},
+
+		// U+003E (GREATER-THAN SIGN)
+		`cn=John\>Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John>Doe"}}},
+		}},
+		`cn=John\3EDoe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John>Doe"}}},
+		}},
+
+		// U+005C (REVERSE SOLIDUS / BACKSLASH)
+		`cn=John\\Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", `John\Doe`}}},
+		}},
+		`cn=John\5CDoe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", `John\Doe`}}},
+		}},
+
+		// U+0000 (NULL) — RFC 4514 only allows the hex-escape form.
+		`cn=John\00Doe`: {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"cn", "John\x00Doe"}}},
+		}},
 	}
 
 	for test, answer := range testcases {
@@ -155,12 +235,47 @@ func TestErrorDNParsing(t *testing.T) {
 		`1.3.6.1.4.1.1466.0=test;`:  "DN ended with incomplete type, value pair",
 		"1.3.6.1.4.1.1466.0=test+,": "incomplete type, value pair",
 		"DF=#6666666666665006838820013100000746939546349182108463491821809FBFFFFFFFFF": "failed to decode BER encoding: unexpected EOF",
+
+		// RFC 4514 section 2.4: each of the following characters must be
+		// escaped when they appear in an AttributeValue. The cases below place
+		// the character in a position the spec disallows and expect a parse
+		// error. Some tests may currently fail because the parser does not yet
+		// reject every form of unescaped special character.
+
+		// U+0020 (SPACE) — leading/trailing space in a value must be escaped.
+		// however, the blow is ignored and trimmed for compatibility.
+		// ` cn=John,dc=com` => 'cn=John,dc=com'
+		// `cn=John ,dc=com` => 'cn=John,dc=com'
+
+		// U+0022 (QUOTATION MARK)
+		`cn=John "Doe",dc=com`: "got unescaped character: '\"'",
+
+		// U+002B (PLUS SIGN) — unescaped '+' acts as an RDN attribute separator.
+		"cn=John+": "DN ended with incomplete type, value pair",
+
+		// U+002C (COMMA) — unescaped ',' acts as an RDN separator.
+		"cn=John,": "DN ended with incomplete type, value pair",
+
+		// U+003B (SEMICOLON) — unescaped ';' acts as an RDN separator.
+		"cn=John;": "DN ended with incomplete type, value pair",
+
+		// U+003C (LESS-THAN SIGN)
+		"cn=John<Doe,dc=com": "got unescaped character: '<'",
+
+		// U+003E (GREATER-THAN SIGN)
+		"cn=John>Doe,dc=com": "got unescaped character: '>'",
+
+		// U+005C (REVERSE SOLIDUS) — a lone trailing backslash is a corrupted escape.
+		`cn=John\`: `got corrupted escaped character: 'John\'`,
+
+		// U+0000 (NULL)
+		"cn=John\x00Doe,dc=com": "got unescaped NULL character",
 	}
 
 	for test, answer := range testcases {
-		_, err := ParseDN(test)
+		dn, err := ParseDN(test)
 		if err == nil {
-			t.Errorf("Expected '%s' to fail parsing but succeeded\n", test)
+			t.Errorf("Expected '%s' to fail parsing but succeeded as '%s'\n", test, dn.String())
 		} else if err.Error() != answer {
 			t.Errorf("Unexpected error on: '%s':\nExpected:	%s\nGot:		%s\n", test, answer, err.Error())
 		}
@@ -370,7 +485,7 @@ func TestRoundTripLiteralSubject(t *testing.T) {
 	rdnSequences := map[string]string{
 		"cn=foo-long.com,ou=FooLong,ou=Barq,ou=Baz,ou=Dept.,o=Corp.,c=US":       "cn=foo-long.com,ou=FooLong,ou=Barq,ou=Baz,ou=Dept.,o=Corp.,c=US",
 		"cn=foo-lon❤️\\,g.com,ou=Foo===Long,ou=Ba # rq,ou=Baz,o=C\\; orp.,c=US": "cn=foo-lon\\e2\\9d\\a4\\ef\\b8\\8f\\,g.com,ou=Foo===Long,ou=Ba # rq,ou=Baz,o=C\\; orp.,c=US",
-		"cn=fo\x00o-long.com,ou=\x04FooLong":                                    "cn=fo\\00o-long.com,ou=\\04FooLong",
+		"cn=fo\\00o-long.com,ou=\x04FooLong":                                    "cn=fo\\00o-long.com,ou=\\04FooLong",
 	}
 
 	for subjIn, subjOut := range rdnSequences {
@@ -389,7 +504,6 @@ func TestDecodeString(t *testing.T) {
 	successTestcases := map[string]string{
 		"foo-long.com":      "foo-long.com",
 		"foo-lon❤️\\,g.com": "foo-lon❤️,g.com",
-		"fo\x00o-long.com":  "fo\x00o-long.com",
 		"fo\\00o-long.com":  "fo\x00o-long.com",
 	}
 
@@ -408,6 +522,7 @@ func TestDecodeString(t *testing.T) {
 		"fo\\0":             "failed to decode escaped character: encoding/hex: invalid byte: 0",
 		"fo\\UU️o-long.com": "failed to decode escaped character: encoding/hex: invalid byte: U+0055 'U'",
 		"fo\\0❤️o-long.com": "failed to decode escaped character: invalid byte: 0❤",
+		"fo\x00o-long.com":  "got unescaped NULL character",
 	}
 
 	for encoded, expectedError := range errorTestcases {


### PR DESCRIPTION
## Background

I ran into a case where `ldap.ParseDN` accepted a DN like the following without returning an error:

```
uid=john<doe,ou=engineering,dc=example,dc=com
```

This prompted me to re-read the DN string specification, and I noticed that several of the special characters listed in RFC 4514 were not being checked for the unescaped form.

## Summary

`ParseDN` previously accepted `"`, `;`, `<`, `>`, and NULL (U+0000) in their raw, unescaped form, silently producing `AttributeTypeAndValue` values that violate the RFC 4514 grammar. Such values can be misinterpreted by downstream
LDAP servers or by string-comparison code that assumes a well-formed DN, which is both a correctness issue and a potential security concern (e.g. DN-based authorization checks operating on a value the server later parses differently).

## Changes

- `decodeString` now returns an error when it encounters any of `"`, `;`, `<`, `>`, or NULL in unescaped form. The hex-escape (`\XX`) and backslash-escape (`\X`) forms continue to decode unchanged, so previously valid inputs are unaffected.
- `TestSuccessfulDNParsing` is expanded to cover every RFC 4514 §2.4 escape target in **both** escape forms (e.g. `\,` and `\2C`). NULL is covered only in the hex form, as required by the RFC.
- `TestErrorDNParsing` and `TestDecodeString` gain matching negative cases for each unescaped character, so the new rejection path has full coverage.

## Notes / Caveats

- **Leading/trailing U+0020 (SPACE) is intentionally left lenient.** RFC 4514 requires SPACE at the start/end of a value to be escaped, but the existing whitespace-stripping behavior is relied upon by many real-world inputs. Tightening this is deferred to a separate change to keep this PR backward-compatible for common usage.

## Compatibility

This is a behavior change: callers that were (incorrectly) passing raw `"`, `;`, `<`, `>`, or NULL into `ParseDN` will now receive an error instead of a silently malformed DN. Callers using properly escaped input are unaffected.

## Disclosure on AI assistance

In the interest of transparency:

- The core fix in `v3/dn.go` (rejecting unescaped special characters in `decodeString`) was designed and written by me.
- The additional test cases in `v3/dn_test.go` and the wording of this PR description were drafted with the help of an AI agent. I reviewed every test case against RFC 4514 §2.4 and confirmed the expected behavior locally before submitting.

Happy to adjust or rewrite any part of the AI-assisted content if the maintainers prefer.

## References

- [RFC 4514, Section 2.4 — Converting an AttributeValue from ASN.1 to a String](https://datatracker.ietf.org/doc/html/rfc4514#section-2.4)