### PR TITLE
v3/control: replace unchecked type asserts in DecodeControl with comma-ok

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -565,12 +565,20 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 	case 1:
 		// just type, no criticality or value
 		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
-		ControlType = packet.Children[0].Value.(string)
+		ct, ok := packet.Children[0].Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("control type is not a string: %T", packet.Children[0].Value)
+		}
+		ControlType = ct
 
 	case 2:
 		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
 		if packet.Children[0].Value != nil {
-			ControlType = packet.Children[0].Value.(string)
+			ct, ok := packet.Children[0].Value.(string)
+			if !ok {
+				return nil, fmt.Errorf("control type is not a string: %T", packet.Children[0].Value)
+			}
+			ControlType = ct
 		} else if packet.Children[0].Data != nil {
 			ControlType = packet.Children[0].Data.String()
 		} else {
@@ -579,9 +587,9 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 
 		// Children[1] could be criticality or value (both are optional)
 		// duck-type on whether this is a boolean
-		if _, ok := packet.Children[1].Value.(bool); ok {
+		if crit, ok := packet.Children[1].Value.(bool); ok {
 			packet.Children[1].Description = "Criticality"
-			Criticality = packet.Children[1].Value.(bool)
+			Criticality = crit
 		} else {
 			packet.Children[1].Description = "Control Value"
 			value = packet.Children[1]
@@ -589,10 +597,18 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 
 	case 3:
 		packet.Children[0].Description = "Control Type (" + ControlTypeMap[ControlType] + ")"
-		ControlType = packet.Children[0].Value.(string)
+		ct, ok := packet.Children[0].Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("control type is not a string: %T", packet.Children[0].Value)
+		}
+		ControlType = ct
 
 		packet.Children[1].Description = "Criticality"
-		Criticality = packet.Children[1].Value.(bool)
+		crit, ok := packet.Children[1].Value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("criticality is not a bool: %T", packet.Children[1].Value)
+		}
+		Criticality = crit
 
 		packet.Children[2].Description = "Control Value"
 		value = packet.Children[2]
@@ -729,7 +745,16 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 		c.ControlType = ControlType
 		c.Criticality = Criticality
 		if value != nil {
-			c.ControlValue = value.Value.(string)
+			// A non-conforming or malicious server can send a non-string
+			// (or nil) value here; the previous unchecked cast panicked
+			// the calling goroutine, see #561. Fall back to the raw bytes
+			// when the value isn't a string so we surface an error
+			// instead of crashing.
+			if s, ok := value.Value.(string); ok {
+				c.ControlValue = s
+			} else if value.Data != nil {
+				c.ControlValue = value.Data.String()
+			}
 		}
 		return c, nil
 	}

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
@@ -217,6 +218,86 @@ func TestDecodeControl(t *testing.T) {
 				t.Errorf("DecodeControl() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDecodeControlInvalidTypes(t *testing.T) {
+	// Hand-built packets that previously panicked the caller's
+	// goroutine when DecodeControl cast Value to string or bool
+	// without checking. See #561.
+	intChild := func(n int64) *ber.Packet {
+		return ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, n, "")
+	}
+	strChild := func(s string) *ber.Packet {
+		return ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, s, "")
+	}
+	boolChild := func(b bool) *ber.Packet {
+		return ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, b, "")
+	}
+
+	tests := []struct {
+		name     string
+		children []*ber.Packet
+		wantErr  string
+	}{
+		{
+			name:     "one child, type not a string",
+			children: []*ber.Packet{intChild(42)},
+			wantErr:  "control type is not a string",
+		},
+		{
+			name:     "two children, type not a string",
+			children: []*ber.Packet{intChild(42), boolChild(true)},
+			wantErr:  "control type is not a string",
+		},
+		{
+			name:     "three children, type not a string",
+			children: []*ber.Packet{intChild(42), boolChild(true), strChild("v")},
+			wantErr:  "control type is not a string",
+		},
+		{
+			name:     "three children, criticality not a bool",
+			children: []*ber.Packet{strChild("1.2.3"), intChild(1), strChild("v")},
+			wantErr:  "criticality is not a bool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+			for _, child := range tt.children {
+				p.AppendChild(child)
+			}
+			_, err := DecodeControl(p)
+			if err == nil {
+				t.Fatalf("DecodeControl returned nil error, want one containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecodeControlUnknownTypeNonStringValue(t *testing.T) {
+	// Unknown ControlType with a non-string value used to panic at
+	// value.Value.(string) in the default branch. Now we fall back
+	// to the raw value bytes instead. See #561.
+	p := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+	p.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "1.2.3.4.5", ""))
+	p.AppendChild(ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, false, ""))
+	p.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(99), ""))
+
+	c, err := DecodeControl(p)
+	if err != nil {
+		t.Fatalf("DecodeControl returned error: %v", err)
+	}
+	cs, ok := c.(*ControlString)
+	if !ok {
+		t.Fatalf("DecodeControl returned %T, want *ControlString", c)
+	}
+	if cs.ControlType != "1.2.3.4.5" {
+		t.Errorf("ControlType = %q, want %q", cs.ControlType, "1.2.3.4.5")
 	}
 }
 


### PR DESCRIPTION
Closes #561.

\`DecodeControl\` assumes every controlType is a string and every criticality is a bool, and the default \`ControlString\` case casts \`value.Value.(string)\` unconditionally. When a malformed or hostile server returns a non-string (or nil) in any of these positions, the cast panics the caller's goroutine — the repro in #561 hit the default case where \`value.Value\` was nil:

\`\`\`
panic: interface conversion: interface {} is nil, not string
  go-ldap/ldap/v3.DecodeControl(...)
  go-ldap/ldap/v3.(*Conn).SimpleBind(...)
\`\`\`

Switched every cast to comma-ok form, returning a clear error when the assertion fails. In the default \`ControlString\` branch I fall back to \`value.Data.String()\` when \`value.Value\` isn't a string, so the application gets the raw bytes instead of a crash.

Existing \`TestDecodeControl\` table still passes; the new behaviour only kicks in on input that previously panicked.