### PR TITLE
fix(conn): parse ldapi:// URLs per RFC 4516

### DIFF
--- a/v3/conn.go
+++ b/v3/conn.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -160,10 +161,18 @@ type DialContext struct {
 
 func (dc *DialContext) dial(u *url.URL) (net.Conn, error) {
 	if u.Scheme == "ldapi" {
-		if u.Path == "" || u.Path == "/" {
-			u.Path = "/var/run/slapd/ldapi"
+		// RFC 4516 (and draft-chu-ldap-ldapi) put the socket path in the
+		// host component, percent-encoded; the path is an optional DN.
+		// parseLDAPURL has already decoded the host. Accept the older
+		// ldapi:///path form too so existing callers keep working.
+		path := u.Host
+		if path == "" {
+			path = u.Path
 		}
-		return dc.dialer.Dial("unix", u.Path)
+		if path == "" || path == "/" {
+			path = "/var/run/slapd/ldapi"
+		}
+		return dc.dialer.Dial("unix", path)
 	}
 
 	host, port, err := net.SplitHostPort(u.Host)
@@ -222,12 +231,33 @@ func DialTLS(network, addr string, config *tls.Config) (*Conn, error) {
 	return conn, nil
 }
 
+// parseLDAPURL parses an LDAP URL. It defers to net/url for the common
+// ldap/ldaps/cldap schemes, but handles ldapi specially: the spec puts the
+// unix socket path in the host, percent-encoded with %2F, and net/url rejects
+// that as invalid. Pull the host out manually and decode it.
+func parseLDAPURL(addr string) (*url.URL, error) {
+	const ldapi = "ldapi://"
+	if !strings.HasPrefix(addr, ldapi) {
+		return url.Parse(addr)
+	}
+	rest := addr[len(ldapi):]
+	host, path := rest, ""
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		host, path = rest[:i], rest[i:]
+	}
+	decodedHost, err := url.PathUnescape(host)
+	if err != nil {
+		return nil, fmt.Errorf("ldapi: invalid host %q: %w", host, err)
+	}
+	return &url.URL{Scheme: "ldapi", Host: decodedHost, Path: path}, nil
+}
+
 // DialURL connects to the given ldap URL.
 // The following schemas are supported: ldap://, ldaps://, ldapi://,
 // and cldap:// (RFC1798, deprecated but used by Active Directory).
 // On success a new Conn for the connection is returned.
 func DialURL(addr string, opts ...DialOpt) (*Conn, error) {
-	u, err := url.Parse(addr)
+	u, err := parseLDAPURL(addr)
 	if err != nil {
 		return nil, NewError(ErrorNetwork, err)
 	}

--- a/v3/conn_test.go
+++ b/v3/conn_test.go
@@ -402,3 +402,40 @@ func (c *packetTranslatorConn) SetReadDeadline(t time.Time) error {
 func (c *packetTranslatorConn) SetWriteDeadline(t time.Time) error {
 	return nil
 }
+
+func TestParseLDAPURL(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantHost string
+		wantPath string
+		wantErr  bool
+	}{
+		{"ldap://ldap.example.com:389", "ldap.example.com:389", "", false},
+		{"ldaps://ldap.example.com", "ldap.example.com", "", false},
+		{"ldapi://", "", "", false},
+		{"ldapi:///", "", "/", false},
+		{"ldapi:///var/run/slapd/ldapi", "", "/var/run/slapd/ldapi", false},
+		{"ldapi://%2Fvar%2Frun%2Fslapd%2Fldapi", "/var/run/slapd/ldapi", "", false},
+		{"ldapi://%2Fvar%2Frun%2Fslapd%2Fldapi/dc=example,dc=com", "/var/run/slapd/ldapi", "/dc=example,dc=com", false},
+		{"ldapi://%ZZ", "", "", true},
+	}
+	for _, tc := range tests {
+		u, err := parseLDAPURL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseLDAPURL(%q): expected error, got nil", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseLDAPURL(%q): unexpected error: %v", tc.in, err)
+			continue
+		}
+		if u.Host != tc.wantHost {
+			t.Errorf("parseLDAPURL(%q) host = %q, want %q", tc.in, u.Host, tc.wantHost)
+		}
+		if u.Path != tc.wantPath {
+			t.Errorf("parseLDAPURL(%q) path = %q, want %q", tc.in, u.Path, tc.wantPath)
+		}
+	}
+}


### PR DESCRIPTION
The unix socket path for \`ldapi://\` belongs in the host component, percent-encoded; the path is reserved for a DN. \`net/url\` rejects \`%2F\`-encoded hosts as invalid, so \`DialURL\` never accepted the spec-compliant \`ldapi://%2Fvar%2Frun%2Fldapi\` form and silently dropped through to \`/var/run/slapd/ldapi\` instead.

Added a small \`parseLDAPURL\` that splits and decodes the host for the \`ldapi\` scheme, then defers to \`net/url\` for everything else. The legacy \`ldapi:///path\` form still works.

This is a focused fix for the socket-path parsing; DN handling (using the path component as a default SearchBase, per cpuschma's comment on the issue) is left as a separate change.

Closes #564.