### PR TITLE
fix: decode Server Side Sorting controlValue as BER-encoded OCTET STRING per RFC 2891

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -946,28 +946,39 @@ func (c *ControlServerSideSorting) GetControlType() string {
 }
 
 func NewControlServerSideSorting(value *ber.Packet) (*ControlServerSideSorting, error) {
-	sortKeys := []*SortKey{}
+	val, err := ber.DecodePacketErr(value.Data.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("decode packet err: %s", err)
+	}
 
-	val := value.Children[1].Children
-
-	if len(val) != 1 {
+	if len(val.Children) == 0 {
 		return nil, fmt.Errorf("no sequence value in packet")
 	}
 
-	sequences := val[0].Children
+	var sortKeys []*SortKey
 
-	for i, sequence := range sequences {
-		sortKey := new(SortKey)
-
-		if len(sequence.Children) < 2 {
-			return nil, fmt.Errorf("attributeType or matchingRule is missing from sequence %d", i)
+	for i, sequence := range val.Children {
+		if len(sequence.Children) < 1 || len(sequence.Children) > 3 {
+			return nil, fmt.Errorf("attributeType is missing from sequence %d", i)
 		}
 
-		sortKey.AttributeType = sequence.Children[0].Value.(string)
-		sortKey.MatchingRule = sequence.Children[1].Value.(string)
+		sortKey := new(SortKey)
 
-		if len(sequence.Children) == 3 {
-			sortKey.Reverse = sequence.Children[2].Value.(bool)
+		for _, child := range sequence.Children {
+			switch {
+			case child.ClassType == ber.ClassUniversal && child.Tag == ber.TagOctetString:
+				sortKey.AttributeType = child.Value.(string)
+
+			case child.ClassType == ber.ClassContext && child.Tag == 0:
+				sortKey.MatchingRule = child.Data.String()
+
+			case child.ClassType == ber.ClassContext && child.Tag == 1:
+				b := child.Data.Bytes()
+				sortKey.Reverse = len(b) > 0 && b[0] != 0
+			}
+		}
+		if sortKey.AttributeType == "" {
+			return nil, fmt.Errorf("attributeType is missing from sequence %d", i)
 		}
 
 		sortKeys = append(sortKeys, sortKey)
@@ -984,7 +995,6 @@ func (c *ControlServerSideSorting) Encode() *ber.Packet {
 	packet := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
 	control := ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, c.GetControlType(), "Control Type")
 
-	value := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value")
 	seqs := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "SortKeyList")
 
 	for _, f := range c.SortKeys {
@@ -993,9 +1003,11 @@ func (c *ControlServerSideSorting) Encode() *ber.Packet {
 		seq.AppendChild(
 			ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, f.AttributeType, "attributeType"),
 		)
-		seq.AppendChild(
-			ber.NewString(ber.ClassContext, ber.TypePrimitive, 0, f.MatchingRule, "orderingRule"),
-		)
+		if f.MatchingRule != "" {
+			seq.AppendChild(
+				ber.NewString(ber.ClassContext, ber.TypePrimitive, 0, f.MatchingRule, "orderingRule"),
+			)
+		}
 		if f.Reverse {
 			seq.AppendChild(
 				ber.NewBoolean(ber.ClassContext, ber.TypePrimitive, 1, f.Reverse, "reverseOrder"),
@@ -1005,7 +1017,7 @@ func (c *ControlServerSideSorting) Encode() *ber.Packet {
 		seqs.AppendChild(seq)
 	}
 
-	value.AppendChild(seqs)
+	value := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, string(seqs.Bytes()), "Control Value")
 
 	packet.AppendChild(control)
 	packet.AppendChild(value)

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -198,6 +198,10 @@ func TestDecodeControl(t *testing.T) {
 			name: "passwordInHistory", args: args{packet: ber.DecodePacket([]byte{0xa0, 0x24, 0x30, 0x22, 0x4, 0x19, 0x31, 0x2e, 0x33, 0x2e, 0x36, 0x2e, 0x31, 0x2e, 0x34, 0x2e, 0x31, 0x2e, 0x34, 0x32, 0x2e, 0x32, 0x2e, 0x32, 0x37, 0x2e, 0x38, 0x2e, 0x35, 0x2e, 0x31, 0x4, 0x5, 0x30, 0x3, 0x81, 0x1, 0x8})},
 			want: &ControlBeheraPasswordPolicy{Expire: -1, Grace: -1, Error: 8, ErrorString: "New password is in list of old passwords"}, wantErr: false,
 		},
+		{
+			name: "serverSideSort", args: args{packet: ber.DecodePacket([]byte{160, 36, 48, 34, 4, 22, 49, 46, 50, 46, 56, 52, 48, 46, 49, 49, 51, 53, 53, 54, 46, 49, 46, 52, 46, 52, 55, 51, 4, 8, 48, 6, 48, 4, 4, 2, 99, 110})},
+			want: &ControlServerSideSorting{SortKeys: []*SortKey{{Reverse: false, AttributeType: "cn", MatchingRule: ""}}}, wantErr: false,
+		},
 	}
 	for i := range tests {
 		err := addControlDescriptions(tests[i].args.packet)
@@ -312,11 +316,11 @@ func TestControlServerSideSortingDecoding(t *testing.T) {
 		Reverse:       false,
 	}, {
 		MatchingRule:  "",
-		AttributeType: "",
+		AttributeType: "cn",
 		Reverse:       false,
 	}, {
 		MatchingRule:  "totoRule",
-		AttributeType: "",
+		AttributeType: "cn",
 		Reverse:       false,
 	}, {
 		MatchingRule:  "",
@@ -324,7 +328,8 @@ func TestControlServerSideSortingDecoding(t *testing.T) {
 		Reverse:       false,
 	}})
 
-	controlDecoded, err := NewControlServerSideSorting(control.Encode())
+	// NewControlServerSideSorting need control's value, not the whole control
+	controlDecoded, err := NewControlServerSideSorting(control.Encode().Children[1])
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**Description**

This pull request fixes a panic in `NewControlServerSideSorting` caused by misaligned BER encoding and decoding of the control value relative to RFC 2891 Section 1.1. Per the RFC, the `controlValue` is an OCTET STRING whose content is the BER encoding of `SortKeyList`. The original code treated it as a direct BER child (`value.Children[1].Children`), which panicked with `index out of range [1] with length 0` when decoding a correctly structured control from any conformant LDAP server — `value.Children` is empty because the bytes are in `value.Data`.

`Encode()` had the inverse bug: it appended the `SortKeyList` SEQUENCE as a direct BER child (`value.AppendChild(seqs)`) instead of embedding its serialized bytes inside the OCTET STRING.

**Changes**

- **`NewControlServerSideSorting`**: replaced `value.Children[1].Children` with `ber.DecodePacketErr(value.Data.Bytes())` to correctly decode the BER-encoded `SortKeyList` from the OCTET STRING's raw bytes.
- **`Encode`**: moved the `value` construction to after `seqs` is built, changed to `string(seqs.Bytes())` to embed the serialized bytes inside the OCTET STRING per the RFC wire format.
- **Sort key parsing**: replaced hardcoded positional indexes with tag-and-class-driven dispatch via a `switch` over `child.ClassType` and `child.Tag`, so that optional `orderingRule` `[0]` and `reverseOrder` `[1]` are identified by their BER tags rather than position.
- **`Encode` orderingRule**: only appends the `orderingRule` child when `MatchingRule != ""`, matching the optional semantics of the RFC.

**Testing**

- Added a test case `"serverSideSort"` in `TestDecodeControl` with a real BER-encoded control packet (controlType `1.2.840.113556.1.4.473` with sort key `cn`) to verify `DecodeControl` roundtrip.
- Fixed `TestControlServerSideSortingDecoding`: pass `control.Encode().Children[1]` (the control value) instead of `control.Encode()` (the whole control), matching how `DecodeControl` invokes `NewControlServerSideSorting`. Also corrected test sort keys from `AttributeType: ""` to `"cn"` — `attributeType` is required per RFC 2891 and the updated parsing logic now validates that it is non-empty.
- Existing tests pass successfully.

**Additional Notes**

- The fix aligns with the `ControlServerSideSortingResult` pattern already used in this file, where `pkt` nil handling was added for OpenLDAP compatibility.
- This is the same class of fix as commit `5937e97`, which added bounds checks to six other functions for malformed BER responses.
- No breaking changes introduced.