### PR TITLE
fix: escape quoted-string metacharacters in digest-md5 response

### DIFF
--- a/v3/bind.go
+++ b/v3/bind.go
@@ -368,14 +368,24 @@ func computeResponse(params map[string]string, uri, username, password string) (
 	resp := enchex.EncodeToString(md5Hash([]byte(kd)))
 	return fmt.Sprintf(
 		`username="%s",realm="%s",nonce="%s",cnonce="%s",nc=00000001,qop=%s,digest-uri="%s",response=%s`,
-		username,
-		params["realm"],
-		params["nonce"],
+		quotedStringEscape(username),
+		quotedStringEscape(params["realm"]),
+		quotedStringEscape(params["nonce"]),
 		cnonce,
 		qop,
-		uri,
+		quotedStringEscape(uri),
 		resp,
 	), nil
+}
+
+// quotedStringEscape escapes the two characters that may not appear unescaped
+// inside a DIGEST-MD5 quoted string per RFC 2831 section 7.1: the backslash
+// and the double quote. The backslash is replaced first so the quotes escaped
+// afterwards are not doubled.
+func quotedStringEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
 }
 
 func md5Hash(b []byte) []byte {

--- a/v3/bind_test.go
+++ b/v3/bind_test.go
@@ -55,6 +55,25 @@ func TestConn_Bind(t *testing.T) {
 	}
 }
 
+func TestComputeResponseQuotesSpecialChars(t *testing.T) {
+	// A username carrying a double quote or backslash must be emitted as a
+	// properly escaped DIGEST-MD5 quoted string, otherwise it breaks out of
+	// the username directive and injects further directives into the response.
+	params := map[string]string{"realm": "example.com", "nonce": "abc"}
+	resp, err := computeResponse(params, "ldap/host", `a"b\c`, "secret")
+	assert.NoError(t, err)
+	assert.Contains(t, resp, `username="a\"b\\c"`)
+}
+
+func TestComputeResponseQuotesServerRealm(t *testing.T) {
+	// realm and nonce come from the server challenge and are echoed back
+	// inside quoted strings, so they need the same escaping.
+	params := map[string]string{"realm": `r"x`, "nonce": "abc"}
+	resp, err := computeResponse(params, "ldap/host", "user", "secret")
+	assert.NoError(t, err)
+	assert.Contains(t, resp, `realm="r\"x"`)
+}
+
 func TestConn_UnauthenticatedBind(t *testing.T) {
 	l, err := getTestConnection(false)
 	if err != nil {


### PR DESCRIPTION
1. `computeResponse` writes `username`, `realm`, `nonce` and `digest-uri` straight into the quoted-string directives of the digest-response without escaping `\` and `"`, which RFC 2831 section 7.1 requires for a quoted string.
2. A `"` in the username (application supplied) or in the server-supplied realm/nonce that gets echoed back closes the directive early and injects extra directives into the SASL credential, e.g. username `a",realm="x` yields a second `realm=` in the response.
3. Added `quotedStringEscape` and applied it to each quoted value. The digest is still computed over the raw values, so only the wire encoding changes and the server recovers the same values after unescaping.

Validation: added two unit tests in `bind_test.go` that fail on the current code (the raw quote breaks out) and pass with the escape applied.