### PR TITLE
fix: escape attribute and matching rule in DecompileFilter

### DIFF
--- a/v3/filter.go
+++ b/v3/filter.go
@@ -131,7 +131,7 @@ func DecompileFilter(packet *ber.Packet) (_ string, err error) {
 		buf.WriteString(childStr)
 
 	case FilterSubstrings:
-		buf.WriteString(ber.DecodeString(packet.Children[0].Data.Bytes()))
+		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[0].Data.Bytes())))
 		buf.WriteByte('=')
 		for i, child := range packet.Children[1].Children {
 			if i == 0 && child.Tag != FilterSubstringsInitial {
@@ -143,22 +143,22 @@ func DecompileFilter(packet *ber.Packet) (_ string, err error) {
 			}
 		}
 	case FilterEqualityMatch:
-		buf.WriteString(ber.DecodeString(packet.Children[0].Data.Bytes()))
+		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[0].Data.Bytes())))
 		buf.WriteByte('=')
 		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes())))
 	case FilterGreaterOrEqual:
-		buf.WriteString(ber.DecodeString(packet.Children[0].Data.Bytes()))
+		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[0].Data.Bytes())))
 		buf.WriteString(">=")
 		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes())))
 	case FilterLessOrEqual:
-		buf.WriteString(ber.DecodeString(packet.Children[0].Data.Bytes()))
+		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[0].Data.Bytes())))
 		buf.WriteString("<=")
 		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes())))
 	case FilterPresent:
-		buf.WriteString(ber.DecodeString(packet.Data.Bytes()))
+		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Data.Bytes())))
 		buf.WriteString("=*")
 	case FilterApproxMatch:
-		buf.WriteString(ber.DecodeString(packet.Children[0].Data.Bytes()))
+		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[0].Data.Bytes())))
 		buf.WriteString("~=")
 		buf.WriteString(EscapeFilter(ber.DecodeString(packet.Children[1].Data.Bytes())))
 	case FilterExtensibleMatch:
@@ -181,14 +181,14 @@ func DecompileFilter(packet *ber.Packet) (_ string, err error) {
 		}
 
 		if len(attr) > 0 {
-			buf.WriteString(attr)
+			buf.WriteString(EscapeFilter(attr))
 		}
 		if dnAttributes {
 			buf.WriteString(":dn")
 		}
 		if len(matchingRule) > 0 {
 			buf.WriteString(":")
-			buf.WriteString(matchingRule)
+			buf.WriteString(EscapeFilter(matchingRule))
 		}
 		buf.WriteString(":=")
 		buf.WriteString(EscapeFilter(value))

--- a/v3/filter_test.go
+++ b/v3/filter_test.go
@@ -258,6 +258,33 @@ func TestInvalidFilter(t *testing.T) {
 	}
 }
 
+func TestDecompileFilterEscapesAttribute(t *testing.T) {
+	eq := ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterEqualityMatch, nil, FilterMap[FilterEqualityMatch])
+	eq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "uid)(uid=admin", "Attribute"))
+	eq.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "x", "Condition"))
+
+	got, err := DecompileFilter(eq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `(uid\29\28uid=admin=x)`; got != want {
+		t.Errorf("equality attribute not escaped: got %q want %q", got, want)
+	}
+
+	em := ber.Encode(ber.ClassContext, ber.TypeConstructed, FilterExtensibleMatch, nil, FilterMap[FilterExtensibleMatch])
+	em.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, MatchingRuleAssertionMatchingRule, "1)(x=*", MatchingRuleAssertionMap[MatchingRuleAssertionMatchingRule]))
+	em.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, MatchingRuleAssertionType, "cn*evil", MatchingRuleAssertionMap[MatchingRuleAssertionType]))
+	em.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, MatchingRuleAssertionMatchValue, "v", MatchingRuleAssertionMap[MatchingRuleAssertionMatchValue]))
+
+	got, err = DecompileFilter(em)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `(cn\2aevil:1\29\28x=\2a:=v)`; got != want {
+		t.Errorf("extensible match attribute/rule not escaped: got %q want %q", got, want)
+	}
+}
+
 func BenchmarkFilterCompile(b *testing.B) {
 	b.StopTimer()
 	filters := make([]string, len(testFilters))


### PR DESCRIPTION
1. DecompileFilter runs the assertion value through EscapeFilter, but the attribute description (equality, substrings, >=, <=, ~=, present) and the extensible-match attribute and matching rule are written to the output verbatim.
2. A filter packet from an untrusted peer whose attribute or matching-rule bytes contain the filter metacharacters ()*\ breaks out of its component and injects extra clauses into the reconstructed string. An equality packet with attribute uid)(uid=admin decompiles to (uid)(uid=admin=x).

Ran each attribute emission and the extensible-match matching rule through EscapeFilter, the same way the value is already handled. Legitimate attribute descriptors are ASCII and contain none of the escaped characters, so existing round-trips are unchanged. Added a regression test that builds the crafted packets and checks the metacharacters come back escaped.
