### PR TITLE
fix: set Result code when decoding ServerSideSortingResult control

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -1097,6 +1097,8 @@ func NewControlServerSideSortingResult(pkt *ber.Packet) (*ControlServerSideSorti
 		return nil, err
 	}
 
+	control.Result = ControlServerSideSortingCode(codeInt)
+
 	return control, nil
 }
 

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -358,3 +358,18 @@ func TestControlServerSideSortingDecoding(t *testing.T) {
 		}
 	}
 }
+
+func TestControlServerSideSortingResultDecoding(t *testing.T) {
+	for _, code := range ControlServerSideSortingCodes {
+		control := &ControlServerSideSortingResult{Result: code}
+
+		decoded, err := NewControlServerSideSortingResult(control.Encode())
+		if err != nil {
+			t.Fatalf("failed to decode result code %d: %s", code, err)
+		}
+
+		if decoded.Result != code {
+			t.Fatalf("result code mismatch: encoded %d - decoded %d", code, decoded.Result)
+		}
+	}
+}


### PR DESCRIPTION
Repro: a server returns a sortResult control whose resultCode is non-zero, for example noSuchAttribute (16) or insufficientAccessRights (50).
Cause: NewControlServerSideSortingResult reads and validates the code with ParseInt64 and Valid(), but never assigns it, so control.Result keeps its zero value (success) no matter what the server sent.
Fix: store the validated code in control.Result before returning, so callers see the actual sort outcome. Verified with a round-trip test over every defined code; it fails on the current tree and passes with the change.