### PR TITLE
fix: reject trailing bytes in hex-encoded DN attribute value

### DIFF
--- a/v3/dn.go
+++ b/v3/dn.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -244,9 +245,17 @@ func decodeEncodedString(str string) (string, error) {
 		return "", fmt.Errorf("failed to decode BER encoding: %w", err)
 	}
 
-	packet, err := ber.DecodePacketErr(decoded)
+	// RFC 4514 section 2.4: the value following '#' is the hex encoding of the
+	// BER encoding of a single AttributeValue. Read exactly one element and
+	// reject any leftover octets, otherwise bytes appended after the value are
+	// silently dropped and two different DN strings decode to the same value.
+	reader := bytes.NewBuffer(decoded)
+	packet, err := ber.ReadPacket(reader)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode BER encoding: %w", err)
+	}
+	if reader.Len() != 0 {
+		return "", errors.New("failed to decode BER encoding: trailing bytes after value")
 	}
 
 	return packet.Data.String(), nil

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -229,6 +229,8 @@ func TestErrorDNParsing(t *testing.T) {
 		"cn=Jim\\0":                 "failed to decode escaped character: encoding/hex: invalid byte: 0",
 		"DC=example,=net":           "DN ended with incomplete type, value pair",
 		"1=#0402486":                "failed to decode BER encoding: encoding/hex: odd length hex string",
+		"1=#0402486900":             "failed to decode BER encoding: trailing bytes after value",
+		"1=#04024869ffff,DC=net":    "failed to decode BER encoding: trailing bytes after value",
 		"test,DC=example,DC=com":    "incomplete type, value pair",
 		"=test,DC=example,DC=com":   "incomplete type, value pair",
 		"1.3.6.1.4.1.1466.0=test+":  "DN ended with incomplete type, value pair",


### PR DESCRIPTION
1. setValue hands the hex after '#' to decodeEncodedString, which hex-decodes it and calls ber.DecodePacketErr.
2. DecodePacketErr reads one BER element and drops any trailing octets, so CN=#04024869 and CN=#0402486900ffff decode to the same value and DN.Equal / EqualFold treat the two DN strings as equal. RFC 4514 section 2.4 defines the value after '#' as the hex of the BER encoding of a single AttributeValue, so leftover octets are not valid.
3. Read a single element with ber.ReadPacket over a bytes.Buffer and reject the value when octets remain after it.

Added the two trailing-byte cases to TestErrorDNParsing; valid #-hex values still parse unchanged.