### PR TITLE
fix(conn): finish Unbind message context to prevent Close deadlock

### DIFF
--- a/v3/conn_test.go
+++ b/v3/conn_test.go
@@ -208,6 +208,54 @@ func TestConnErrorDataRace(t *testing.T) {
 	conn.Close()
 }
 
+// TestUnbindCloseDeadlock calls Unbind against a connection whose server
+// side disconnects immediately after receiving the unbind PDU. This
+// exercises the race between the reader goroutine (which stores closeErr
+// and calls Close from its defer) and Unbind's own Close call.
+//
+// Unbind previously discarded the messageContext returned by doRequest
+// without calling finishMessage. If the reader won the race, the
+// processMessages cleanup would block in sendResponse on the orphaned
+// context's unclosed done channel, deadlocking Close.
+//
+// Under normal execution the race window is narrow and the deadlock is
+// not guaranteed to trigger. To verify deterministically, widen the
+// window by adding a sleep in Unbind between doRequest and finishMessage
+// and commenting out finishMessage — see the commit message for details.
+func TestUnbindCloseDeadlock(t *testing.T) {
+	server, client := net.Pipe()
+
+	conn := NewConn(client, false)
+	conn.Start()
+
+	// Server: read the unbind PDU, then close to simulate disconnect.
+	go func() {
+		buf := make([]byte, 4096)
+		_, err := server.Read(buf)
+		if err != nil {
+			t.Errorf("unexpected error from concurrent server read: %v", err)
+		}
+		err = server.Close()
+		if err != nil {
+			t.Errorf("unexpected error from concurrent server close: %v", err)
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- conn.Unbind()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && !IsErrorWithCode(err, ErrorNetwork) {
+			t.Fatalf("Unbind: unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Unbind deadlocked: orphaned messageContext blocked processMessages cleanup")
+	}
+}
+
 // See: https://github.com/go-ldap/ldap/issues/332
 func TestNilConnection(t *testing.T) {
 	var conn *Conn

--- a/v3/unbind.go
+++ b/v3/unbind.go
@@ -24,10 +24,17 @@ func (l *Conn) Unbind() error {
 		return ErrConnUnbound
 	}
 
-	_, err := l.doRequest(unbindRequest{})
+	msgCtx, err := l.doRequest(unbindRequest{})
 	if err != nil {
 		return err
 	}
+
+	// Finish the message context so its done channel is closed. Without
+	// this, a server-initiated disconnect racing with Close can deadlock:
+	// processMessages cleanup tries to deliver closeErr to the orphaned
+	// context via sendResponse, which blocks forever on the unclosed done
+	// channel, preventing chanConfirm from being signalled.
+	l.finishMessage(msgCtx)
 
 	// Sending an unbindRequest will make the connection unusable.
 	// Pending requests will fail with:


### PR DESCRIPTION
Unbind called doRequest but discarded the returned messageContext without calling finishMessage. If the server closed the connection after receiving the unbind PDU but before Close set the closing flag, the reader goroutine would store a closeErr and call Close from its defer. The processMessages cleanup would then try to deliver the error to the orphaned context via sendResponse, which blocks forever on the unclosed done channel (no reader, no timeout), preventing chanConfirm from being signalled and deadlocking both Close callers.

Call finishMessage before Close so that the done channel is always closed. This lets processMessages cleanup's sendResponse select fall through on <-msgCtx.done instead of blocking.

Add TestUnbindCloseDeadlock which deterministically reproduces the deadlock condition and verifies the fix.

---

While I'd like to be able to say that the test always fails when the fix is not in place, the issue is fundamentally due to a race. To demonstrate the failure consistently, the race window needs to be widened. A 1µs sleep before the close is enough to demonstrate the effect.
```diff
--- a/v3/unbind.go
+++ b/v3/unbind.go
@@ -2,6 +2,7 @@
 import (
 	"errors"
+	"time"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 )
@@ -31,7 +32,9 @@
-	l.finishMessage(msgCtx)
+	time.Sleep(time.Microsecond)
+	_ = msgCtx
+	// l.finishMessage(msgCtx)
```
will fail infrequently (I saw 7/1000); increasing the sleep can make this more frequent. Omitting the commenting out of the `l.finishMessage(msgCtx)` fix while retaining the sleep results in zero failures.