### PR TITLE
unescape quoted-pair sequences in digest-md5 challenge parser

### DIFF
--- a/v3/bind.go
+++ b/v3/bind.go
@@ -294,6 +294,7 @@ func parseParams(str string) (map[string]string, error) {
 	m := make(map[string]string)
 	var key, value string
 	var state int
+	var escaped bool
 	for i := 0; i <= len(str); i++ {
 		switch state {
 		case 0: // reading key
@@ -328,10 +329,20 @@ func parseParams(str string) (map[string]string, error) {
 			if i == len(str) {
 				return nil, fmt.Errorf("syntax error on %d", i)
 			}
-			if str[i] != '"' {
+			switch {
+			case escaped:
+				// RFC 2831 section 7.1 quoted-pair: a backslash escapes the
+				// following character, so the next byte is taken literally
+				// (this is how a server sends a literal " or \ in a realm or
+				// nonce).
 				value += string(str[i])
-			} else {
+				escaped = false
+			case str[i] == '\\':
+				escaped = true
+			case str[i] == '"':
 				state = 1
+			default:
+				value += string(str[i])
 			}
 		}
 	}

--- a/v3/bind_test.go
+++ b/v3/bind_test.go
@@ -74,6 +74,18 @@ func TestComputeResponseQuotesServerRealm(t *testing.T) {
 	assert.Contains(t, resp, `realm="r\"x"`)
 }
 
+func TestParseParamsUnescapesQuotedPair(t *testing.T) {
+	// The DIGEST-MD5 challenge is sent by the server as comma-separated
+	// directives whose values are quoted strings. Per RFC 2831 section 7.1 a
+	// literal double quote or backslash inside such a value is sent as a
+	// quoted-pair (\" or \\), so the parser has to unescape it. Without that
+	// the value is truncated at the escaped quote and the bind fails.
+	params, err := parseParams(`realm="a\"b",nonce="c\\d"`)
+	assert.NoError(t, err)
+	assert.Equal(t, `a"b`, params["realm"])
+	assert.Equal(t, `c\d`, params["nonce"])
+}
+
 func TestConn_UnauthenticatedBind(t *testing.T) {
 	l, err := getTestConnection(false)
 	if err != nil {


### PR DESCRIPTION
1. The DIGEST-MD5 challenge `parseParams` reads server directives whose values are RFC 2831 quoted strings, where a literal `"` or `\` is sent as a quoted-pair (`\"` or `\\`).
2. The in-quotes state treats `\` as an ordinary byte and closes the value at the escaped `"`, so a challenge such as `realm="a\"b"` is mis-split, the leftover bytes raise a syntax error, and the bind aborts; values that do parse keep the stray backslash and feed the wrong realm/nonce into the digest computation.

Handle the quoted-pair inside the quoted state so the byte following a backslash is taken literally. This is the read side of the escaping added in #595. Verified with a new `parseParams` test that decodes `realm="a\"b",nonce="c\\d"` to the literal `a"b` and `c\d`; it errors out before the change.