### PR TITLE
fix: synchronize writes to Conn.err with GetLastError

### DIFF
--- a/v3/conn.go
+++ b/v3/conn.go
@@ -113,7 +113,11 @@ type Conn struct {
 	outstandingRequests uint
 	messageMutex        sync.Mutex
 
-	err error
+	// errMutex guards err only. It is a leaf lock: processMessages and reader
+	// record errors while another goroutine may hold messageMutex, so err must
+	// not share messageMutex or those writers could deadlock.
+	errMutex sync.Mutex
+	err      error
 }
 
 var _ Client = &Conn{}
@@ -368,9 +372,19 @@ func (l *Conn) nextMessageID() int64 {
 // GetLastError returns the last recorded error from goroutines like processMessages and reader.
 // Only the last recorded error will be returned.
 func (l *Conn) GetLastError() error {
-	l.messageMutex.Lock()
-	defer l.messageMutex.Unlock()
+	l.errMutex.Lock()
+	defer l.errMutex.Unlock()
 	return l.err
+}
+
+// setError records the connection's last error. The background goroutines that
+// call it (processMessages, reader, the per-request timeout helper and the
+// SearchAsync worker) run concurrently with callers of GetLastError, so the
+// write must take the mutex the getter reads under.
+func (l *Conn) setError(err error) {
+	l.errMutex.Lock()
+	defer l.errMutex.Unlock()
+	l.err = err
 }
 
 // StartTLS sends the command to start a TLS session and then creates a new TLS Client
@@ -521,7 +535,7 @@ func (l *Conn) sendProcessMessage(message *messagePacket) bool {
 func (l *Conn) processMessages() {
 	defer func() {
 		if err := recover(); err != nil {
-			l.err = fmt.Errorf("ldap: recovered panic in processMessages: %v", err)
+			l.setError(fmt.Errorf("ldap: recovered panic in processMessages: %v", err))
 		}
 		for messageID, msgCtx := range l.messageContexts {
 			// If we are closing due to an error, inform anyone who
@@ -571,7 +585,7 @@ func (l *Conn) processMessages() {
 						timer := time.NewTimer(time.Duration(requestTimeout))
 						defer func() {
 							if err := recover(); err != nil {
-								l.err = fmt.Errorf("ldap: recovered panic in RequestTimeout: %v", err)
+								l.setError(fmt.Errorf("ldap: recovered panic in RequestTimeout: %v", err))
 							}
 
 							timer.Stop()
@@ -593,7 +607,7 @@ func (l *Conn) processMessages() {
 				if msgCtx, ok := l.messageContexts[message.MessageID]; ok {
 					msgCtx.sendResponse(&PacketResponse{message.Packet, nil}, time.Duration(l.getTimeout()))
 				} else {
-					l.err = fmt.Errorf("ldap: received unexpected message %d, %v", message.MessageID, l.IsClosing())
+					l.setError(fmt.Errorf("ldap: received unexpected message %d, %v", message.MessageID, l.IsClosing()))
 					l.Debug.PrintPacket(message.Packet)
 				}
 			case MessageTimeout:
@@ -620,7 +634,7 @@ func (l *Conn) reader() {
 	cleanstop := false
 	defer func() {
 		if err := recover(); err != nil {
-			l.err = fmt.Errorf("ldap: recovered panic in reader: %v", err)
+			l.setError(fmt.Errorf("ldap: recovered panic in reader: %v", err))
 		}
 		if !cleanstop {
 			l.Close()

--- a/v3/conn_test.go
+++ b/v3/conn_test.go
@@ -163,6 +163,51 @@ func TestFinishMessage(t *testing.T) {
 	conn.Close()
 }
 
+// TestConnErrorDataRace ensures the background goroutines that record the
+// connection's last error are synchronized with callers reading it through
+// GetLastError. Run under -race it fails when the writes bypass the mutex the
+// getter holds.
+func TestConnErrorDataRace(t *testing.T) {
+	ptc := newPacketTranslatorConn()
+	defer ptc.Close()
+
+	conn := NewConn(ptc, false)
+	conn.Start()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = conn.GetLastError()
+			}
+		}
+	}()
+
+	// Responses carrying message IDs with no outstanding request drive
+	// processMessages into the branch that records an unexpected-message error.
+	for i := 0; i < 100; i++ {
+		response := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+		response.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(900000+i), "MessageID"))
+		response.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, 0, "Response"))
+		if err := ptc.SendResponse(response); err != nil {
+			t.Fatalf("unable to send response packet: %s", err)
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+	wg.Wait()
+
+	conn.Close()
+}
+
 // See: https://github.com/go-ldap/ldap/issues/332
 func TestNilConnection(t *testing.T) {
 	var conn *Conn

--- a/v3/response.go
+++ b/v3/response.go
@@ -71,7 +71,7 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 		defer func() {
 			close(r.ch)
 			if err := recover(); err != nil {
-				r.conn.err = fmt.Errorf("ldap: recovered panic in searchResponse: %v", err)
+				r.conn.setError(fmt.Errorf("ldap: recovered panic in searchResponse: %v", err))
 			}
 		}()
 


### PR DESCRIPTION
1. GetLastError reads Conn.err while holding a mutex, but processMessages, the reader goroutine, the per-request timeout helper, and the SearchAsync worker all assign Conn.err without holding any lock.
2. A caller polling GetLastError while one of those background goroutines records an error is a data race on the error interface value, which go test -race (run by CI) reports.
3. The writes can't reuse messageMutex, since sendProcessMessage holds it while sending on chanMessage that processMessages must stay free to receive, so a dedicated errMutex leaf lock now backs both GetLastError and a new setError helper that the writers go through.

Added a regression test that drives the unexpected-message path against a concurrent GetLastError; it fails under -race before the change and passes after.