### PR TITLE
fix: avoid uint16 overflow in gssapi UnmarshalWrapToken offset

### DIFF
--- a/v3/gssapi/client.go
+++ b/v3/gssapi/client.go
@@ -258,7 +258,11 @@ func UnmarshalWrapToken(wt *gssapi.WrapToken, b []byte, expectFromAcceptor bool)
 		return fmt.Errorf("inconsistent checksum length: %d bytes to parse, checksum length is %d", len(b), checksumL)
 	}
 
-	payloadStart := 16 + checksumL
+	// Compute the offset in int. checksumL is a uint16 read from the wire, so
+	// 16 + checksumL overflows the uint16 range once checksumL exceeds 65519,
+	// wrapping to a small value and turning the slices below into out-of-range
+	// accesses that panic the bind goroutine.
+	payloadStart := gssapi.HdrLen + int(checksumL)
 
 	wt.Flags = flags
 	wt.EC = checksumL

--- a/v3/gssapi/client_test.go
+++ b/v3/gssapi/client_test.go
@@ -1,0 +1,54 @@
+package gssapi
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+)
+
+// wrapTokenHeader builds a valid 16-byte acceptor WrapToken header with the
+// given checksum length (EC) field.
+func wrapTokenHeader(checksumLen uint16) []byte {
+	h := make([]byte, gssapi.HdrLen)
+	h[0], h[1] = 0x05, 0x04 // token id
+	h[2] = 0x01             // acceptor flag set
+	h[3] = gssapi.FillerByte
+	binary.BigEndian.PutUint16(h[4:6], checksumLen)
+	return h
+}
+
+// A malicious server can set the checksum-length field high enough that
+// 16 + checksumL overflows uint16. The sanity check still passes because the
+// token is large, so the bad offset reached the slice operations.
+func TestUnmarshalWrapTokenChecksumLengthOverflow(t *testing.T) {
+	const checksumLen = uint16(0xFFFF)
+	b := wrapTokenHeader(checksumLen)
+	// Pad so len(b)-HdrLen >= checksumLen and the sanity check is satisfied.
+	b = append(b, make([]byte, int(checksumLen))...)
+
+	wt := &gssapi.WrapToken{}
+	if err := UnmarshalWrapToken(wt, b, true); err != nil {
+		t.Logf("got expected error: %v", err)
+	}
+}
+
+func TestUnmarshalWrapTokenSplit(t *testing.T) {
+	checksum := []byte{0xaa, 0xbb, 0xcc, 0xdd}
+	payload := []byte("payload")
+
+	b := wrapTokenHeader(uint16(len(checksum)))
+	b = append(b, checksum...)
+	b = append(b, payload...)
+
+	wt := &gssapi.WrapToken{}
+	if err := UnmarshalWrapToken(wt, b, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(wt.CheckSum) != string(checksum) {
+		t.Errorf("checksum: got %x, want %x", wt.CheckSum, checksum)
+	}
+	if string(wt.Payload) != string(payload) {
+		t.Errorf("payload: got %q, want %q", wt.Payload, payload)
+	}
+}


### PR DESCRIPTION
Repro: have the server return a GSSAPI wrap token during a SASL/GSSAPI bind whose checksum-length (EC) field is 0xFFFF, in a token at least 65551 bytes long so the existing length check still passes.
Cause: UnmarshalWrapToken computes the payload offset as 16 + checksumL with checksumL a uint16, so the sum wraps for EC values above 65519, payloadStart becomes a small value, and the following b[16:payloadStart] / b[payloadStart:] slices go out of range and panic the bind goroutine.
Fix: compute the offset in int (gssapi.HdrLen + int(checksumL)), the same way gokrb5 WrapToken.Unmarshal does it; the length check already bounds checksumL, so valid tokens are unchanged.

Verified with a unit test that feeds the oversized EC value (panics before the change, returns without panic after) and a second test that checks the checksum/payload split for a normal token.