### PR TITLE
fix: respect backslash parity for escaped trailing space in DN value

### DIFF
--- a/v3/dn.go
+++ b/v3/dn.go
@@ -96,9 +96,21 @@ func (d *DN) String() string {
 func stripLeadingAndTrailingSpaces(inVal string) string {
 	noSpaces := strings.Trim(inVal, " ")
 
-	// Re-add the trailing space if it was an escaped space
-	if len(noSpaces) > 0 && noSpaces[len(noSpaces)-1] == '\\' && inVal[len(inVal)-1] == ' ' {
-		noSpaces = noSpaces + " "
+	// Re-add the trailing space only if it was escaped. A trailing space is
+	// escaped when it is preceded by an odd number of backslashes; an even
+	// number leaves the space unescaped (each "\\" is a literal backslash), so
+	// the space is insignificant and stays stripped. Counting only the final
+	// backslash treated "\\ " (a literal backslash plus an insignificant
+	// space) as an escaped space, keeping a spurious trailing space in the
+	// decoded value.
+	if len(noSpaces) > 0 && inVal[len(inVal)-1] == ' ' {
+		backslashes := 0
+		for i := len(noSpaces) - 1; i >= 0 && noSpaces[i] == '\\'; i-- {
+			backslashes++
+		}
+		if backslashes%2 == 1 {
+			noSpaces = noSpaces + " "
+		}
 	}
 
 	return noSpaces

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -533,3 +533,30 @@ func TestDecodeString(t *testing.T) {
 		assert.EqualError(t, err, expectedError)
 	}
 }
+
+func TestDecodeStringTrailingSpace(t *testing.T) {
+	// A trailing space is significant only when escaped by an odd number of
+	// backslashes. An even number leaves it unescaped and insignificant, so it
+	// must be stripped rather than kept by the preceding backslash.
+	testcases := map[string]string{
+		`admin\ `:    "admin ",  // 1 backslash: escaped space, kept
+		`admin\\ `:   `admin\`,  // 2 backslashes: literal '\', space stripped
+		`admin\\\ `:  `admin\ `, // 3 backslashes: literal '\' + escaped space
+		`admin\\\\ `: `admin\\`, // 4 backslashes: two literal '\', space stripped
+	}
+	for encoded, decoded := range testcases {
+		decodedString, err := decodeString(encoded)
+		if err != nil {
+			t.Fatalf("decodeString(%q): %v", encoded, err)
+		}
+		assert.Equal(t, decoded, decodedString, "decodeString(%q)", encoded)
+	}
+
+	// Two DN strings that differ only by an insignificant trailing space must
+	// compare equal under distinguishedNameMatch.
+	a, err := ParseDN(`CN=admin\\`)
+	assert.NoError(t, err)
+	b, err := ParseDN(`CN=admin\\ `)
+	assert.NoError(t, err)
+	assert.True(t, a.Equal(b), `ParseDN("CN=admin\\") should equal ParseDN("CN=admin\\ ")`)
+}


### PR DESCRIPTION
1. stripLeadingAndTrailingSpaces keeps a trailing space whenever the trimmed value ends in a backslash, but a doubled `\\` escape also ends in a backslash, so a literal backslash followed by an insignificant space looks like an escaped space.
2. `admin\\ ` therefore decodes to `admin\ ` instead of `admin\`, and `CN=admin\\` and `CN=admin\\ ` parse to different values that compare unequal under DN.Equal / EqualFold (RFC 4517 distinguishedNameMatch).

Count the consecutive trailing backslashes and only re-add the space when that count is odd; an even count leaves the space unescaped and insignificant. Added a decodeString/ParseDN regression test covering 1-4 backslashes before a trailing space.