### PR TITLE
fix: compare multi-valued RDN attributes as a multiset

### DIFF
--- a/v3/dn.go
+++ b/v3/dn.go
@@ -372,10 +372,19 @@ func (r *RelativeDN) Equal(other *RelativeDN) bool {
 }
 
 func (r *RelativeDN) hasAllAttributes(attrs []*AttributeTypeAndValue) bool {
+	// Each candidate attribute must match a distinct attribute of the receiver.
+	// Without consuming matches this is a set containment test, so a multi-valued
+	// RDN that repeats an attributeTypeAndValue would compare equal to one that
+	// repeats a different pair the same number of times.
+	matched := make([]bool, len(r.Attributes))
 	for _, attr := range attrs {
 		found := false
-		for _, myattr := range r.Attributes {
+		for i, myattr := range r.Attributes {
+			if matched[i] {
+				continue
+			}
 			if myattr.Equal(attr) {
+				matched[i] = true
 				found = true
 				break
 			}
@@ -435,10 +444,16 @@ func (r *RelativeDN) EqualFold(other *RelativeDN) bool {
 }
 
 func (r *RelativeDN) hasAllAttributesFold(attrs []*AttributeTypeAndValue) bool {
+	// See hasAllAttributes: matches are consumed so multiplicity is respected.
+	matched := make([]bool, len(r.Attributes))
 	for _, attr := range attrs {
 		found := false
-		for _, myattr := range r.Attributes {
+		for i, myattr := range r.Attributes {
+			if matched[i] {
+				continue
+			}
 			if myattr.EqualFold(attr) {
+				matched[i] = true
 				found = true
 				break
 			}

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -320,6 +320,10 @@ func TestDNEqual(t *testing.T) {
 		{"o=A+o=B", "O=B+o=A+O=C", false}, // missing values matter
 		{"o=A+o=B+o=C", "O=B+o=A", false}, // missing values matter
 
+		// Repeated attribute value multiplicity is significant
+		{"o=A+o=A+o=B", "o=A+o=B+o=B", false}, // same values, different counts
+		{"o=A+o=A+o=B", "o=A+o=A+o=B", true},  // identical repeats still match
+
 		// Whitespace tests
 		// Matching
 		{
@@ -390,6 +394,10 @@ func TestDNEqualFold(t *testing.T) {
 		{"o=A", "O=a", true},
 		{"o=A,o=b", "o=a,O=B", true},
 		{"o=a+o=B", "o=A+O=b", true},
+
+		// Repeated attribute value multiplicity is significant
+		{"o=A+o=a+o=B", "o=a+o=A+o=b", true},  // two folded a's and one b on both sides
+		{"o=A+o=a+o=b", "o=a+o=b+o=B", false}, // {a:2,b:1} vs {a:1,b:2}
 	}
 
 	for i, tc := range testcases {


### PR DESCRIPTION
RelativeDN.Equal and EqualFold check that both RDNs have the same number of attributes and then test containment in each direction, but the containment helpers never consume a match, so they compare the attribute sets rather than multisets. A multi-valued RDN that repeats an attributeTypeAndValue, such as cn=a+cn=a+cn=b, then compares equal to cn=a+cn=b+cn=b under distinguishedNameMatch even though DN.String renders the two differently. I mark each receiver attribute as used once it matches so repeated values are counted, and added the multiplicity cases to the existing equality tables.