### PR TITLE
decode extended responseName by context class

### DIFF
--- a/v3/extended.go
+++ b/v3/extended.go
@@ -89,6 +89,14 @@ func (l *Conn) Extended(er *ExtendedRequest) (*ExtendedResponse, error) {
 	}
 
 	for _, child := range extResp.Children {
+		// responseName [10] and responseValue [11] are context-class and
+		// optional. The preceding resultCode is a universal ENUMERATED whose
+		// tag number (10) is the same as responseName, so a child must be
+		// matched on its class as well, otherwise the resultCode is read as
+		// the responseName whenever the server omits the latter.
+		if child.ClassType != ber.ClassContext {
+			continue
+		}
 		switch child.Tag {
 		case ber.TagEnumerated:
 			response.Name = child.Data.String()

--- a/v3/extended_test.go
+++ b/v3/extended_test.go
@@ -42,11 +42,11 @@ func TestExtendedRequest_WhoAmI(t *testing.T) {
 // report the result code as the name.
 func TestExtendedResponseNameOmitted(t *testing.T) {
 	ptc := newPacketTranslatorConn()
-	defer ptc.Close()
+	defer func() { _ = ptc.Close() }()
 
 	conn := NewConn(ptc, false)
 	conn.Start()
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	go func() {
 		req, err := ptc.ReceiveRequest()

--- a/v3/extended_test.go
+++ b/v3/extended_test.go
@@ -3,6 +3,7 @@ package ldap
 import (
 	"testing"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,6 +34,42 @@ func TestExtendedRequest_WhoAmI(t *testing.T) {
 	rfc4532resp, err = l.Extended(rfc4532req)
 	assert.NoError(t, err)
 	t.Logf("%#v\n", rfc4532resp)
+}
+
+// TestExtendedResponseNameOmitted feeds a successful ExtendedResponse that
+// carries a responseValue but no responseName. The resultCode is a universal
+// ENUMERATED whose tag number matches responseName [10]; decoding must not
+// report the result code as the name.
+func TestExtendedResponseNameOmitted(t *testing.T) {
+	ptc := newPacketTranslatorConn()
+	defer ptc.Close()
+
+	conn := NewConn(ptc, false)
+	conn.Start()
+	defer conn.Close()
+
+	go func() {
+		req, err := ptc.ReceiveRequest()
+		if err != nil {
+			return
+		}
+		msgID := req.Children[0].Value.(int64)
+
+		resp := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+		resp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, msgID, "MessageID"))
+		extResp := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationExtendedResponse, nil, "Extended Response")
+		extResp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, 0, "resultCode"))
+		extResp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "matchedDN"))
+		extResp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "diagnosticMessage"))
+		extResp.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, ber.TagEmbeddedPDV, "payload", "responseValue"))
+		resp.AppendChild(extResp)
+		_ = ptc.SendResponse(resp)
+	}()
+
+	result, err := conn.Extended(NewExtendedRequest("1.2.3.4", nil))
+	assert.NoError(t, err)
+	assert.Equal(t, "", result.Name)
+	assert.NotNil(t, result.Value)
 }
 
 func TestExtendedRequest_FastBind(t *testing.T) {


### PR DESCRIPTION
1. In `Conn.Extended` the ExtendedResponse children are matched on `child.Tag` only: tag 10 sets `Name` and tag 11 sets `Value`.
2. The optional `responseName` is `[10]` context-class, but the `resultCode` that always precedes it is a universal `ENUMERATED` with the same tag number, so the result code matches the name case. When a server omits `responseName` (the usual case), `ExtendedResponse.Name` ends up holding the raw result code octet (`"\x00"` on success) instead of an empty string.
3. Skip non-context-class children before the tag switch, so only the context-tagged `responseName`/`responseValue` are read. This mirrors the class-aware decoding already used for other controls.

Verified with a regression test that drives `Extended` over the in-package fake connection with a success response that carries a `responseValue` but no `responseName`; it asserts `Name` is empty and fails on the current code (`Name == "\x00"`).