### PR TITLE
strip surrounding spaces before hexstring form in DN value

### DIFF
--- a/v3/dn.go
+++ b/v3/dn.go
@@ -37,16 +37,14 @@ func (a *AttributeTypeAndValue) setValue(s string) error {
 	// AttributeValue is represented by an number sign ('#' U+0023)
 	// character followed by the hexadecimal encoding of each of the octets
 	// of the BER encoding of the X.500 AttributeValue.
-	if len(s) > 0 && s[0] == '#' {
-		decodedString, err := decodeEncodedString(s[1:])
-		if err != nil {
-			return err
-		}
-
-		a.Value = decodedString
-		return nil
-	} else {
-		decodedString, err := decodeString(s)
+	//
+	// Insignificant leading and trailing spaces around the value are stripped
+	// for the string form (see decodeString). Detect and decode the hexstring
+	// form after the same stripping so that "O= #0402..." and "O=#0402... "
+	// parse identically to "O=#0402...", instead of being misread as the
+	// literal string "#0402..." or rejected outright.
+	if trimmed := strings.Trim(s, " "); len(trimmed) > 0 && trimmed[0] == '#' {
+		decodedString, err := decodeEncodedString(trimmed[1:])
 		if err != nil {
 			return err
 		}
@@ -54,6 +52,14 @@ func (a *AttributeTypeAndValue) setValue(s string) error {
 		a.Value = decodedString
 		return nil
 	}
+
+	decodedString, err := decodeString(s)
+	if err != nil {
+		return err
+	}
+
+	a.Value = decodedString
+	return nil
 }
 
 // String returns a normalized string representation of this attribute type and

--- a/v3/dn_test.go
+++ b/v3/dn_test.go
@@ -35,6 +35,18 @@ func TestSuccessfulDNParsing(t *testing.T) {
 			{[]*AttributeTypeAndValue{{"1.3.6.1.4.1.1466.0", "Hi"}}},
 			{[]*AttributeTypeAndValue{{"DC", "net"}}},
 		}},
+		// Insignificant spaces around the hexstring form are stripped, matching
+		// the string form, so these parse the same as "1=#04024869".
+		"1= #04024869": {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"1", "Hi"}}},
+		}},
+		"1=#04024869 ,DC=net": {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"1", "Hi"}}},
+			{[]*AttributeTypeAndValue{{"DC", "net"}}},
+		}},
+		"1=  #04024869  ": {[]*RelativeDN{
+			{[]*AttributeTypeAndValue{{"1", "Hi"}}},
+		}},
 		"CN=Lu\\C4\\8Di\\C4\\87": {[]*RelativeDN{
 			{[]*AttributeTypeAndValue{{"CN", "Lučić"}}},
 		}},


### PR DESCRIPTION
1. setValue detects the RFC 4514 hexstring value form by testing the raw value for a leading `#` and hex-decodes it before any space stripping, but the string form is stripped of insignificant leading and trailing spaces by decodeString.
2. so a value written in the hexstring form with surrounding spaces is parsed inconsistently: `O= #04024869` is read as the literal string `#04024869` and `O=#04024869 ` is rejected, while the canonical `O=#04024869` decodes to the BER value `Hi`.
3. the first two then compare unequal to the canonical form under DN.Equal/EqualFold (distinguishedNameMatch, used for identity comparisons), or a valid value fails to parse.

Strip the surrounding spaces before detecting and decoding the hexstring form, matching the string form and the existing `  CN  =  ...  ` handling already covered in the parse tests. Added parse cases for the leading, trailing, and both-sides forms.