### PR TITLE
handle linear whitespace in digest-md5 challenge parser

### DIFF
--- a/v3/bind.go
+++ b/v3/bind.go
@@ -301,6 +301,15 @@ func parseParams(str string) (map[string]string, error) {
 			if i == len(str) {
 				return nil, fmt.Errorf("syntax error on %d", i)
 			}
+			// The digest-challenge is an RFC 2068 #rule (RFC 2831 section 2.1.1),
+			// which permits optional linear whitespace around the comma directive
+			// separators. Directive names are tokens that never contain
+			// whitespace, so skip it here; otherwise a directive following
+			// "..., name" is keyed with a leading space and the lookups in
+			// computeResponse (realm, nonce, authzid) miss it.
+			if str[i] == ' ' || str[i] == '\t' {
+				continue
+			}
 			if str[i] != '=' {
 				key += string(str[i])
 				continue
@@ -310,6 +319,14 @@ func parseParams(str string) (map[string]string, error) {
 			if i == len(str) {
 				m[key] = value
 				break
+			}
+			// Linear whitespace outside a quoted string is not part of the
+			// value: an unquoted value is a token and a quoted value's content
+			// is read in the quoted state below. Skipping it lets a challenge
+			// using the whitespace the #rule allows (e.g. `nonce="n" , qop=auth`)
+			// parse the same as the unspaced form.
+			if str[i] == ' ' || str[i] == '\t' {
+				continue
 			}
 			switch str[i] {
 			case ',':

--- a/v3/bind_test.go
+++ b/v3/bind_test.go
@@ -86,6 +86,26 @@ func TestParseParamsUnescapesQuotedPair(t *testing.T) {
 	assert.Equal(t, `c\d`, params["nonce"])
 }
 
+func TestParseParamsLinearWhitespace(t *testing.T) {
+	// The DIGEST-MD5 challenge is an RFC 2068 #rule (RFC 2831 section 2.1.1),
+	// so a conforming server may put optional linear whitespace around the
+	// comma directive separators. Every directive after the first must still be
+	// keyed by its name; otherwise the leading space makes realm/nonce lookups
+	// in computeResponse return empty and the bind digest is computed over the
+	// wrong parameters.
+	params, err := parseParams(`realm="example.com", nonce="abc123" , qop=auth`)
+	assert.NoError(t, err)
+	assert.Equal(t, "example.com", params["realm"])
+	assert.Equal(t, "abc123", params["nonce"])
+	assert.Equal(t, "auth", params["qop"])
+
+	// Whitespace inside a quoted value is still significant and must be kept.
+	params, err = parseParams(`realm="a b", nonce="c d"`)
+	assert.NoError(t, err)
+	assert.Equal(t, "a b", params["realm"])
+	assert.Equal(t, "c d", params["nonce"])
+}
+
 func TestConn_UnauthenticatedBind(t *testing.T) {
 	l, err := getTestConnection(false)
 	if err != nil {


### PR DESCRIPTION
1. the DIGEST-MD5 challenge is an RFC 2068 #rule (RFC 2831 section 2.1.1), so a server may put optional linear whitespace around the comma directive separators.
2. parseParams appended every non-`=` byte to the key, so `realm="x", nonce="y", qop=auth` keyed the later directives as " nonce" and " qop"; computeResponse then looks up realm/nonce/authzid by exact name, gets empty strings, and computes the response over the wrong parameters.
Skipped space and tab outside quoted strings (directive names and unquoted token values never contain whitespace, and quoted content is still read in the in-quotes state), then added a parser test covering whitespace around separators and significant whitespace inside quotes.