### PR TITLE
fix: avoid out-of-range index for serverSaslCreds in saslBindTokenExchange

### DIFF
--- a/v3/bind.go
+++ b/v3/bind.go
@@ -836,7 +836,10 @@ RESP:
 		}
 		switch resultCode.Value.(int64) {
 		case 14: // Sasl bind in progress
-			if len(protocolOp.Children) < 3 {
+			// serverSaslCreds is the optional [7] field that follows the
+			// three LDAPResult components, so it sits at child index 3 and
+			// requires at least four children to be present.
+			if len(protocolOp.Children) < 4 {
 				break RESP
 			}
 			referral := protocolOp.Children[3]

--- a/v3/bind_test.go
+++ b/v3/bind_test.go
@@ -2,7 +2,9 @@ package ldap
 
 import (
 	"testing"
+	"time"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -116,4 +118,65 @@ func TestConn_UnauthenticatedBind(t *testing.T) {
 	err = l.UnauthenticatedBind("cn=admin," + baseDN)
 	assert.Error(t, err)
 	assert.Truef(t, IsErrorWithCode(err, LDAPResultUnwillingToPerform), "Expected LDAPResultUnwillingToPerform, got %v", err)
+}
+
+// TestSASLBindTokenExchangeShortInProgress feeds a saslBindInProgress response
+// that omits the optional serverSaslCreds, so the protocolOp carries only the
+// three LDAPResult components. The length guard before reading the creds child
+// must reject it instead of indexing past the slice.
+func TestSASLBindTokenExchangeShortInProgress(t *testing.T) {
+	ptc := newPacketTranslatorConn()
+	defer ptc.Close()
+
+	conn := NewConn(ptc, false)
+	conn.Start()
+	defer conn.Close()
+
+	type result struct {
+		err       error
+		panicked  bool
+		panicData interface{}
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		var res result
+		defer func() {
+			if r := recover(); r != nil {
+				res.panicked = true
+				res.panicData = r
+			}
+			resCh <- res
+		}()
+		_, res.err = conn.saslBindTokenExchange(nil, []byte("client-token"))
+	}()
+
+	req, err := ptc.ReceiveRequest()
+	if err != nil {
+		t.Fatalf("receive request: %v", err)
+	}
+	msgID := req.Children[0].Value.(int64)
+
+	resp := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+	resp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, msgID, "MessageID"))
+	bindResp := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationBindResponse, nil, "Bind Response")
+	bindResp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, 14, "resultCode"))
+	bindResp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "matchedDN"))
+	bindResp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "diagnosticMessage"))
+	resp.AppendChild(bindResp)
+
+	if err := ptc.SendResponse(resp); err != nil {
+		t.Fatalf("send response: %v", err)
+	}
+
+	select {
+	case res := <-resCh:
+		if res.panicked {
+			t.Fatalf("saslBindTokenExchange panicked on short response: %v", res.panicData)
+		}
+		if res.err == nil {
+			t.Fatal("expected an error for a saslBindInProgress response without serverSaslCreds")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("saslBindTokenExchange did not return")
+	}
 }

--- a/v3/bind_test.go
+++ b/v3/bind_test.go
@@ -126,11 +126,11 @@ func TestConn_UnauthenticatedBind(t *testing.T) {
 // must reject it instead of indexing past the slice.
 func TestSASLBindTokenExchangeShortInProgress(t *testing.T) {
 	ptc := newPacketTranslatorConn()
-	defer ptc.Close()
+	defer func() { _ = ptc.Close() }()
 
 	conn := NewConn(ptc, false)
 	conn.Start()
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	type result struct {
 		err       error


### PR DESCRIPTION
1. saslBindTokenExchange reads serverSaslCreds at protocolOp.Children[3] for a saslBindInProgress (result code 14) response, but the length check ahead of it only required three children.
2. serverSaslCreds is the optional [7] field that follows the three LDAPResult components, so a server that returns code 14 with only those components makes the index out of range and panics the bind goroutine mid GSSAPI handshake.

Require at least four children before reading the creds child, so a short response falls through to GetLDAPError instead of indexing past the slice. Added a regression test that drives the exchange with a three-child in-progress response.