### PR TITLE
fix: skip empty referral sequence in getReferral

### DIFF
--- a/v3/request.go
+++ b/v3/request.go
@@ -101,6 +101,14 @@ func getReferral(err error, packet *ber.Packet) (referral string) {
 			continue
 		}
 
+		// A Referral is a SEQUENCE SIZE (1..MAX) OF uri, but a non-conforming or
+		// malicious server can send an empty SEQUENCE. Skip it instead of indexing
+		// child.Children[0], which would panic the goroutine that called Modify or
+		// PasswordModify.
+		if len(child.Children) == 0 {
+			continue
+		}
+
 		if referral, ok = child.Children[0].Value.(string); ok {
 			return referral
 		}

--- a/v3/request_test.go
+++ b/v3/request_test.go
@@ -1,0 +1,52 @@
+package ldap
+
+import (
+	"testing"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+)
+
+// buildReferralResponse builds a ModifyResponse envelope whose result code is a
+// referral. When withURI is false the referral SEQUENCE is left empty, which is
+// what a non-conforming or malicious server can send.
+func buildReferralResponse(withURI bool) *ber.Packet {
+	envelope := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+	envelope.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, 2, "MessageID"))
+
+	resp := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationModifyResponse, nil, "Modify Response")
+	resp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, int64(LDAPResultReferral), "resultCode"))
+	resp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "matchedDN"))
+	resp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "referral", "errorMessage"))
+
+	referral := ber.Encode(ber.ClassContext, ber.TypeConstructed, ber.TagBitString, nil, "Referral")
+	if withURI {
+		referral.AppendChild(ber.NewString(ber.ClassContext, ber.TypePrimitive, ber.TagBitString, "ldap://ds.example.com/", "uri"))
+	}
+	resp.AppendChild(referral)
+
+	envelope.AppendChild(resp)
+	return envelope
+}
+
+func TestGetReferralEmptySequence(t *testing.T) {
+	packet := buildReferralResponse(false)
+	err := GetLDAPError(packet)
+	if !IsErrorWithCode(err, LDAPResultReferral) {
+		t.Fatalf("expected referral error, got %v", err)
+	}
+
+	// An empty referral SEQUENCE must not panic the caller.
+	if got := getReferral(err, packet); got != "" {
+		t.Errorf("expected empty referral, got %q", got)
+	}
+}
+
+func TestGetReferralWithURI(t *testing.T) {
+	packet := buildReferralResponse(true)
+	err := GetLDAPError(packet)
+
+	const want = "ldap://ds.example.com/"
+	if got := getReferral(err, packet); got != want {
+		t.Errorf("expected referral %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Repro: a server returns a Modify or PasswordModify referral result (resultCode 10) whose referral is an empty SEQUENCE with no URI.
Cause: getReferral selects the referral child by tag/type/class and then reads child.Children[0] without checking the SEQUENCE is non-empty. A Referral is SEQUENCE SIZE (1..MAX) OF uri, but a non-conforming server can send it empty; the empty constructed node still passes the filter, so the index panics the goroutine that called Modify/PasswordModify (both run synchronously, with no recover).
Fix: skip a matching child that has no children, so an empty referral yields the same empty string returned when no referral is present.

Verified with a unit test that builds a referral response with an empty referral sequence: it panics on the current code at request.go:104 and returns "" after the change, while a referral carrying a URI still decodes to that URI.