### PR TITLE
fix: guard malformed paging control in DecodeControl

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -622,6 +622,9 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 	case ControlTypeManageDsaIT:
 		return NewControlManageDsaIT(Criticality), nil
 	case ControlTypePaging:
+		if value == nil {
+			return nil, fmt.Errorf("paging control value is missing")
+		}
 		value.Description += " (Paging)"
 		c := new(ControlPaging)
 		if value.Value != nil {
@@ -633,11 +636,21 @@ func DecodeControl(packet *ber.Packet) (Control, error) {
 			value.Value = nil
 			value.AppendChild(valueChildren)
 		}
+		if len(value.Children) == 0 {
+			return nil, fmt.Errorf("paging control value is empty")
+		}
 		value = value.Children[0]
 		value.Description = "Search Control Value"
+		if len(value.Children) < 2 {
+			return nil, fmt.Errorf("paging control value has %d children, expected 2", len(value.Children))
+		}
 		value.Children[0].Description = "Paging Size"
 		value.Children[1].Description = "Cookie"
-		c.PagingSize = uint32(value.Children[0].Value.(int64))
+		pagingSize, ok := value.Children[0].Value.(int64)
+		if !ok {
+			return nil, fmt.Errorf("paging size is not an integer: %T", value.Children[0].Value)
+		}
+		c.PagingSize = uint32(pagingSize)
 		c.Cookie = value.Children[1].Data.Bytes()
 		value.Children[1].Value = c.Cookie
 		return c, nil

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -16,6 +16,72 @@ func TestControlPaging(t *testing.T) {
 	runControlTest(t, NewControlPaging(100))
 }
 
+func TestDecodeControlPagingMalformed(t *testing.T) {
+	// Hand-built paging response controls that previously panicked the
+	// caller's goroutine: a missing value (nil deref) and a value whose
+	// inner sequence is empty or too short (index out of range).
+	typeChild := func() *ber.Packet {
+		return ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, ControlTypePaging, "Control Type")
+	}
+	valueWithSeq := func(children ...*ber.Packet) *ber.Packet {
+		v := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value (Paging)")
+		seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Search Control Value")
+		for _, c := range children {
+			seq.AppendChild(c)
+		}
+		v.AppendChild(seq)
+		return v
+	}
+
+	tests := []struct {
+		name     string
+		children []*ber.Packet
+		wantErr  string
+	}{
+		{
+			name:     "missing value",
+			children: []*ber.Packet{typeChild(), ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, true, "Criticality")},
+			wantErr:  "paging control value is missing",
+		},
+		{
+			name:     "empty value sequence",
+			children: []*ber.Packet{typeChild(), valueWithSeq()},
+			wantErr:  "expected 2",
+		},
+		{
+			name: "value sequence with one child",
+			children: []*ber.Packet{typeChild(), valueWithSeq(
+				ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(0), "Paging Size"),
+			)},
+			wantErr: "expected 2",
+		},
+		{
+			name: "paging size not an integer",
+			children: []*ber.Packet{typeChild(), valueWithSeq(
+				ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "x", "Paging Size"),
+				ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "Cookie"),
+			)},
+			wantErr: "paging size is not an integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Control")
+			for _, child := range tt.children {
+				p.AppendChild(child)
+			}
+			_, err := DecodeControl(p)
+			if err == nil {
+				t.Fatalf("DecodeControl returned nil error, want one containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestControlManageDsaIT(t *testing.T) {
 	runControlTest(t, NewControlManageDsaIT(true))
 	runControlTest(t, NewControlManageDsaIT(false))


### PR DESCRIPTION
DecodeControl reads the paging response control a server returns in a SearchResultDone, but the ControlTypePaging branch dereferences the control value and indexes its inner sequence without checking the value is present or that it holds the two expected elements, and it asserts the page size to int64 directly. A server that returns a paging control with no value, with an empty or short value sequence, or with a non-integer size panics the synchronous Search caller, which runs without a recover. This validates the value and the sequence shape and rejects a non-integer size so a malformed control returns an error instead of crashing the caller.