### PR TITLE
guard malformed attribute in unpackAttributes

### DIFF
--- a/v3/response.go
+++ b/v3/response.go
@@ -126,10 +126,15 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 
 				switch packet.Children[1].Tag {
 				case ApplicationSearchResultEntry:
+					attributes, err := unpackAttributes(packet.Children[1].Children[1].Children)
+					if err != nil {
+						r.ch <- &SearchSingleResult{Error: err}
+						return
+					}
 					result := &SearchSingleResult{
 						Entry: &Entry{
 							DN:         packet.Children[1].Children[0].Value.(string),
-							Attributes: unpackAttributes(packet.Children[1].Children[1].Children),
+							Attributes: attributes,
 						},
 					}
 					if len(packet.Children) != 3 {

--- a/v3/search.go
+++ b/v3/search.go
@@ -595,9 +595,13 @@ func (l *Conn) Search(searchRequest *SearchRequest) (*SearchResult, error) {
 			if len(packet.Children[1].Children) > 1 {
 				attr = packet.Children[1].Children[1].Children
 			}
+			attributes, err := unpackAttributes(attr)
+			if err != nil {
+				return result, err
+			}
 			entry := &Entry{
 				DN:         packet.Children[1].Children[0].Value.(string),
-				Attributes: unpackAttributes(attr),
+				Attributes: attributes,
 			}
 			result.Entries = append(result.Entries, entry)
 		case 5:
@@ -649,19 +653,19 @@ func (l *Conn) Syncrepl(
 
 // unpackAttributes will extract all given LDAP attributes and it's values
 // from the ber.Packet
-func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
+func unpackAttributes(children []*ber.Packet) ([]*EntryAttribute, error) {
 	entries := make([]*EntryAttribute, 0, len(children))
 	for _, child := range children {
 		// A conforming PartialAttribute is SEQUENCE { type, vals SET OF value }.
-		// A non-conforming or malicious server can omit the vals element or send a
-		// non-string type/value; index and assert defensively so a malformed
-		// attribute is skipped instead of panicking the search goroutine.
+		// A non-conforming or malicious server can omit the vals element or send
+		// a non-string type/value; return an error instead of panicking the
+		// search goroutine, so the caller can handle it.
 		if len(child.Children) < 2 {
-			continue
+			return nil, fmt.Errorf("ldap: malformed attribute: expected 2 children (type and vals), got %d", len(child.Children))
 		}
 		name, ok := child.Children[0].Value.(string)
 		if !ok {
-			continue
+			return nil, fmt.Errorf("ldap: malformed attribute: type is not a string: %T", child.Children[0].Value)
 		}
 		values := child.Children[1].Children
 		entry := &EntryAttribute{
@@ -673,13 +677,17 @@ func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
 		}
 
 		for i, value := range values {
+			v, ok := value.Value.(string)
+			if !ok {
+				return nil, fmt.Errorf("ldap: malformed attribute %q: value is not a string: %T", name, value.Value)
+			}
 			entry.ByteValues[i] = value.ByteValue
-			entry.Values[i], _ = value.Value.(string)
+			entry.Values[i] = v
 		}
 		entries = append(entries, entry)
 	}
 
-	return entries
+	return entries, nil
 }
 
 // DirSync does a Search with dirSync Control.

--- a/v3/search.go
+++ b/v3/search.go
@@ -650,22 +650,33 @@ func (l *Conn) Syncrepl(
 // unpackAttributes will extract all given LDAP attributes and it's values
 // from the ber.Packet
 func unpackAttributes(children []*ber.Packet) []*EntryAttribute {
-	entries := make([]*EntryAttribute, len(children))
-	for i, child := range children {
-		length := len(child.Children[1].Children)
+	entries := make([]*EntryAttribute, 0, len(children))
+	for _, child := range children {
+		// A conforming PartialAttribute is SEQUENCE { type, vals SET OF value }.
+		// A non-conforming or malicious server can omit the vals element or send a
+		// non-string type/value; index and assert defensively so a malformed
+		// attribute is skipped instead of panicking the search goroutine.
+		if len(child.Children) < 2 {
+			continue
+		}
+		name, ok := child.Children[0].Value.(string)
+		if !ok {
+			continue
+		}
+		values := child.Children[1].Children
 		entry := &EntryAttribute{
-			Name: child.Children[0].Value.(string),
+			Name: name,
 			// pre-allocate the slice since we can determine
 			// the number of attributes at this point
-			Values:     make([]string, length),
-			ByteValues: make([][]byte, length),
+			Values:     make([]string, len(values)),
+			ByteValues: make([][]byte, len(values)),
 		}
 
-		for i, value := range child.Children[1].Children {
+		for i, value := range values {
 			entry.ByteValues[i] = value.ByteValue
-			entry.Values[i] = value.Value.(string)
+			entry.Values[i], _ = value.Value.(string)
 		}
-		entries[i] = entry
+		entries = append(entries, entry)
 	}
 
 	return entries

--- a/v3/search_test.go
+++ b/v3/search_test.go
@@ -295,20 +295,32 @@ func TestUnpackAttributesMalformed(t *testing.T) {
 	// A conforming attribute decodes as before.
 	good := newPartialAttribute("cn", "first", "second")
 
+	entries, err := unpackAttributes([]*ber.Packet{good})
+	if err != nil {
+		t.Fatalf("unexpected error for a well-formed attribute: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "cn" {
+		t.Fatalf("unexpected entries: %v", entries)
+	}
+	if !reflect.DeepEqual(entries[0].Values, []string{"first", "second"}) {
+		t.Errorf("unexpected attribute values: %v", entries[0].Values)
+	}
+
 	// A non-conforming attribute that omits the vals SET previously indexed
 	// child.Children[1] out of range and panicked the search goroutine.
 	missingVals := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "PartialAttribute")
 	missingVals.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "broken", "Type"))
 
-	entries := unpackAttributes([]*ber.Packet{good, missingVals})
+	if _, err := unpackAttributes([]*ber.Packet{good, missingVals}); err == nil {
+		t.Fatal("expected an error for an attribute without vals")
+	}
 
-	if len(entries) != 1 {
-		t.Fatalf("expected the malformed attribute to be skipped, got %d entries", len(entries))
-	}
-	if entries[0].Name != "cn" {
-		t.Errorf("unexpected attribute name: %q", entries[0].Name)
-	}
-	if !reflect.DeepEqual(entries[0].Values, []string{"first", "second"}) {
-		t.Errorf("unexpected attribute values: %v", entries[0].Values)
+	// A non-string attribute type previously failed the type assertion.
+	badType := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "PartialAttribute")
+	badType.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, int64(1), "Type"))
+	badType.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSet, nil, "Vals"))
+
+	if _, err := unpackAttributes([]*ber.Packet{badType}); err == nil {
+		t.Fatal("expected an error for a non-string attribute type")
 	}
 }

--- a/v3/search_test.go
+++ b/v3/search_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -277,4 +278,37 @@ func TestEntry_UnmarshalFunc(t *testing.T) {
 			}
 		}
 	})
+}
+
+func newPartialAttribute(name string, values ...string) *ber.Packet {
+	attr := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "PartialAttribute")
+	attr.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, name, "Type"))
+	vals := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSet, nil, "Vals")
+	for _, v := range values {
+		vals.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, v, "Value"))
+	}
+	attr.AppendChild(vals)
+	return attr
+}
+
+func TestUnpackAttributesMalformed(t *testing.T) {
+	// A conforming attribute decodes as before.
+	good := newPartialAttribute("cn", "first", "second")
+
+	// A non-conforming attribute that omits the vals SET previously indexed
+	// child.Children[1] out of range and panicked the search goroutine.
+	missingVals := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "PartialAttribute")
+	missingVals.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "broken", "Type"))
+
+	entries := unpackAttributes([]*ber.Packet{good, missingVals})
+
+	if len(entries) != 1 {
+		t.Fatalf("expected the malformed attribute to be skipped, got %d entries", len(entries))
+	}
+	if entries[0].Name != "cn" {
+		t.Errorf("unexpected attribute name: %q", entries[0].Name)
+	}
+	if !reflect.DeepEqual(entries[0].Values, []string{"first", "second"}) {
+		t.Errorf("unexpected attribute values: %v", entries[0].Values)
+	}
 }


### PR DESCRIPTION
1. unpackAttributes indexes child.Children[1] (the vals SET) and asserts the type and each value to string for every attribute of a SearchResultEntry, without checking the server returned a well-formed PartialAttribute.
2. A non-conforming or malicious server that omits the vals element, or sends a non-string type/value, makes the attribute decode index out of range or fail the assertion, which panics the synchronous Search goroutine and the SearchAsync worker. Neither path has a recover, so the caller process crashes.

Return an error for an attribute that lacks the two expected children or whose type or value is not a string, so the caller can handle it: Search returns it to the caller, SearchAsync delivers it on the result channel as SearchSingleResult.Error. Well-formed entries decode exactly as before. Added a unit test covering the missing-vals and non-string-type cases.