### PR TITLE
fix: prevent SearchAsync goroutine leak when context is cancelled during send

### DIFF
--- a/v3/ldap_test.go
+++ b/v3/ldap_test.go
@@ -3,7 +3,6 @@ package ldap
 import (
 	"context"
 	"crypto/tls"
-	"log"
 	"testing"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
@@ -380,7 +379,7 @@ func TestSearchAsync(t *testing.T) {
 		srs = append(srs, r.Entry())
 	}
 	if err := r.Err(); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	t.Logf("TestSearcAsync: %s -> num of entries = %d", searchRequest.Filter, len(srs))
@@ -412,7 +411,7 @@ func TestSearchAsyncAndCancel(t *testing.T) {
 		}
 	}
 	if err := r.Err(); err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	if len(srs) > cancelNum+3 {

--- a/v3/response.go
+++ b/v3/response.go
@@ -66,6 +66,22 @@ func (r *searchResponse) Next() bool {
 	return true
 }
 
+// send enqueues a result on the result channel, giving up when ctx is
+// cancelled so an abandoned consumer cannot block the search goroutine
+// forever on a full buffer. It reports whether the result was handed off to
+// the channel; a true return does not mean the consumer received it. The
+// give-up is best-effort: if ctx is already cancelled but buffer space is
+// available, the result may still be enqueued. Callers that terminate the
+// stream regardless of the outcome may ignore the return value.
+func (r *searchResponse) send(ctx context.Context, res *SearchSingleResult) bool {
+	select {
+	case r.ch <- res:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest) {
 	go func() {
 		defer func() {
@@ -84,14 +100,14 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 		// encode search request
 		err := searchRequest.appendTo(packet)
 		if err != nil {
-			r.ch <- &SearchSingleResult{Error: err}
+			r.send(ctx, &SearchSingleResult{Error: err})
 			return
 		}
 		r.conn.Debug.PrintPacket(packet)
 
 		msgCtx, err := r.conn.sendMessage(packet)
 		if err != nil {
-			r.ch <- &SearchSingleResult{Error: err}
+			r.send(ctx, &SearchSingleResult{Error: err})
 			return
 		}
 		defer r.conn.finishMessage(msgCtx)
@@ -106,19 +122,19 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 			case packetResponse, ok := <-msgCtx.responses:
 				if !ok {
 					err := NewError(ErrorNetwork, errors.New("ldap: response channel closed"))
-					r.ch <- &SearchSingleResult{Error: err}
+					r.send(ctx, &SearchSingleResult{Error: err})
 					return
 				}
 				packet, err = packetResponse.ReadPacket()
 				r.conn.Debug.Printf("%d: got response %p", msgCtx.id, packet)
 				if err != nil {
-					r.ch <- &SearchSingleResult{Error: err}
+					r.send(ctx, &SearchSingleResult{Error: err})
 					return
 				}
 
 				if r.conn.Debug {
 					if err := addLDAPDescriptions(packet); err != nil {
-						r.ch <- &SearchSingleResult{Error: err}
+						r.send(ctx, &SearchSingleResult{Error: err})
 						return
 					}
 					ber.PrintPacket(packet)
@@ -133,22 +149,26 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 						},
 					}
 					if len(packet.Children) != 3 {
-						r.ch <- result
+						if !r.send(ctx, result) {
+							return
+						}
 						continue
 					}
 					decoded, err := DecodeControl(packet.Children[2].Children[0])
 					if err != nil {
 						werr := fmt.Errorf("failed to decode search result entry: %w", err)
 						result.Error = werr
-						r.ch <- result
+						r.send(ctx, result)
 						return
 					}
 					result.Controls = append(result.Controls, decoded)
-					r.ch <- result
+					if !r.send(ctx, result) {
+						return
+					}
 
 				case ApplicationSearchResultDone:
 					if err := GetLDAPError(packet); err != nil {
-						r.ch <- &SearchSingleResult{Error: err}
+						r.send(ctx, &SearchSingleResult{Error: err})
 						return
 					}
 					if len(packet.Children) == 3 {
@@ -157,33 +177,37 @@ func (r *searchResponse) start(ctx context.Context, searchRequest *SearchRequest
 							decodedChild, err := DecodeControl(child)
 							if err != nil {
 								werr := fmt.Errorf("failed to decode child control: %w", err)
-								r.ch <- &SearchSingleResult{Error: werr}
+								r.send(ctx, &SearchSingleResult{Error: werr})
 								return
 							}
 							result.Controls = append(result.Controls, decodedChild)
 						}
-						r.ch <- result
+						r.send(ctx, result)
 					}
 					foundSearchSingleResultDone = true
 
 				case ApplicationSearchResultReference:
 					ref := packet.Children[1].Children[0].Value.(string)
-					r.ch <- &SearchSingleResult{Referral: ref}
+					if !r.send(ctx, &SearchSingleResult{Referral: ref}) {
+						return
+					}
 
 				case ApplicationIntermediateResponse:
 					decoded, err := DecodeControl(packet.Children[1])
 					if err != nil {
 						werr := fmt.Errorf("failed to decode intermediate response: %w", err)
-						r.ch <- &SearchSingleResult{Error: werr}
+						r.send(ctx, &SearchSingleResult{Error: werr})
 						return
 					}
 					result := &SearchSingleResult{}
 					result.Controls = append(result.Controls, decoded)
-					r.ch <- result
+					if !r.send(ctx, result) {
+						return
+					}
 
 				default:
 					err := fmt.Errorf("unknown tag: %d", packet.Children[1].Tag)
-					r.ch <- &SearchSingleResult{Error: err}
+					r.send(ctx, &SearchSingleResult{Error: err})
 					return
 				}
 			}

--- a/v3/response_test.go
+++ b/v3/response_test.go
@@ -1,0 +1,133 @@
+package ldap
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+)
+
+// TestSearchAsyncCancelUnblocksProducer reproduces a goroutine leak in the
+// SearchAsync producer. The doc comment promises "To stop the search, call
+// the cancel function of the context", but the producer only checked ctx while
+// waiting for server packets: when the consumer stopped calling Next() with
+// more undelivered results than the channel buffer holds, the producer
+// blocked forever on the unguarded `r.ch <- result` send and never observed
+// the cancellation, leaking the goroutine and the buffered entries.
+func TestSearchAsyncCancelUnblocksProducer(t *testing.T) {
+	ptc := newPacketTranslatorConn()
+	defer ptc.Close()
+
+	conn := NewConn(ptc, false)
+	conn.Start()
+	// If the producer regresses into a permanent block, a plain conn.Close()
+	// deadlocks behind the leaked goroutine and hangs the whole test binary;
+	// bound it so the failure stays diagnosable.
+	defer runWithTimeout(t, time.Second, func() {
+		conn.Close()
+	})
+
+	// Server: read the search request and reply with more entries than the
+	// result channel can buffer, without a SearchResultDone so the stream
+	// only ends via cancellation.
+	const numEntries = 6
+	go func() {
+		req, err := ptc.ReceiveRequest()
+		if err != nil {
+			// The conn is closed by a deferred cleanup, so this error can
+			// surface after the test has completed, where t.Errorf panics.
+			if err != errPacketTranslatorConnClosed {
+				t.Errorf("unable to receive search request: %s", err)
+			}
+			return
+		}
+		msgID := req.Children[0].Value.(int64)
+		for i := range numEntries {
+			entry := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationSearchResultEntry, nil, "Search Result Entry")
+			entry.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, fmt.Sprintf("cn=user%d,dc=example,dc=com", i), "Object Name"))
+			entry.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "Attributes"))
+
+			response := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+			response.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, msgID, "MessageID"))
+			response.AppendChild(entry)
+			if err := ptc.SendResponse(response); err != nil {
+				if err != errPacketTranslatorConnClosed {
+					t.Errorf("unable to send search result entry: %s", err)
+				}
+				return
+			}
+		}
+	}()
+
+	searchRequest := NewSearchRequest(
+		"dc=example,dc=com",
+		ScopeWholeSubtree, DerefAlways, 0, 0, false,
+		"(objectClass=*)",
+		nil,
+		nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := conn.SearchAsync(ctx, searchRequest, 1)
+
+	// Consume a single entry, then abandon the iteration.
+	if !r.Next() {
+		t.Fatalf("expected an entry, got none: %v", r.Err())
+	}
+
+	// Wait until the producer has filled the buffer again and is therefore
+	// blocked delivering the next result.
+	ch := r.(*searchResponse).ch
+	waitForCondition(t, 3*time.Second, "result channel buffer never filled up", func() bool {
+		return len(ch) == cap(ch)
+	})
+	// A full buffer only implies the producer is about to block; give it a
+	// moment to actually park on the next channel send so that cancellation
+	// exercises the send path rather than the packet-wait select.
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	// The producer goroutine must exit even though nobody drains the
+	// remaining results.
+	waitForCondition(t, 3*time.Second, "searchResponse producer goroutine is still running after context cancellation", func() bool {
+		return !searchProducerRunning()
+	})
+
+	// With the producer gone the result channel is closed: Next drains the
+	// few buffered results and then reports completion.
+	runWithTimeout(t, time.Second, func() {
+		for r.Next() {
+		}
+	})
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatal(msg)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// searchProducerRunning reports whether a SearchAsync producer goroutine is
+// alive by scanning all goroutine stacks. It is coupled to the method name:
+// if (*searchResponse).start is ever renamed, this returns false vacuously
+// and the leak assertion above loses its regression-catching power.
+func searchProducerRunning() bool {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return bytes.Contains(buf[:n], []byte("(*searchResponse).start"))
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}

--- a/v3/response_test.go
+++ b/v3/response_test.go
@@ -20,7 +20,7 @@ import (
 // the cancellation, leaking the goroutine and the buffered entries.
 func TestSearchAsyncCancelUnblocksProducer(t *testing.T) {
 	ptc := newPacketTranslatorConn()
-	defer ptc.Close()
+	defer func() { _ = ptc.Close() }()
 
 	conn := NewConn(ptc, false)
 	conn.Start()
@@ -28,7 +28,7 @@ func TestSearchAsyncCancelUnblocksProducer(t *testing.T) {
 	// deadlocks behind the leaked goroutine and hangs the whole test binary;
 	// bound it so the failure stays diagnosable.
 	defer runWithTimeout(t, time.Second, func() {
-		conn.Close()
+		_ = conn.Close()
 	})
 
 	// Server: read the search request and reply with more entries than the

--- a/v3/search.go
+++ b/v3/search.go
@@ -624,7 +624,10 @@ func (l *Conn) Search(searchRequest *SearchRequest) (*SearchResult, error) {
 // SearchAsync performs a search request and returns all search results asynchronously.
 // This means you get all results until an error happens (or the search successfully finished),
 // e.g. for size / time limited requests all are received until the limit is reached.
-// To stop the search, call cancel function of the context.
+// To stop the search, call the cancel function of the context; Next may
+// still deliver a few results received before the cancellation took effect.
+// Cancellation is not reported as an error: Err returns nil, same as a
+// successfully completed search.
 func (l *Conn) SearchAsync(
 	ctx context.Context, searchRequest *SearchRequest, bufferSize int) Response {
 	r := newSearchResponse(l, bufferSize)
@@ -635,7 +638,8 @@ func (l *Conn) SearchAsync(
 // Syncrepl is a short name for LDAP Sync Replication engine that works on the
 // consumer-side. This can perform a persistent search and returns an entry
 // when the entry is updated on the server side.
-// To stop the search, call cancel function of the context.
+// To stop the search, call the cancel function of the context; cancellation
+// is not reported as an error, Err returns nil.
 func (l *Conn) Syncrepl(
 	ctx context.Context, searchRequest *SearchRequest, bufferSize int,
 	mode ControlSyncRequestMode, cookie []byte, reloadHint bool,


### PR DESCRIPTION
## Summary

`SearchAsync` documents that a running search can be stopped by canceling its context, but that contract isn't fully honored: the producer goroutine leaks if the context is canceled while the producer is parked on a full result channel. The send (`r.ch <- result`) doesn't observe `ctx.Done()`, so cancellation can't unblock it, and the goroutine lives for the rest of the process.

## Background

I introduced `SearchAsync` in #440, so this is a defect in my own design, and I'd like to take responsibility for fixing it.

The leak is narrow: it needs the consumer to abandon iteration while results are still being produced, the buffer to fill, and the cancellation to land while the producer is parked on the send. It's unlikely to matter for most deployments, and I don't consider it urgent — but since the caller is using the API exactly as documented (canceling the context to stop the search) and the producer still fails to terminate, this is a broken contract, not a footgun.

## Root cause

The producer's `select` observed `ctx.Done()` only while waiting to *receive* a packet from the server, never while *sending* a result to the consumer. Cancellation was observable in one blocking path and invisible in the other. A receive is something the producer chooses to wait on; a send only blocks because the consumer stopped reading, which is easy to overlook and never shows up in happy-path tests.

## Fix

Route every send through a helper that makes the send and `ctx.Done()` symmetric cases of one `select`:

```go
func (r *searchResponse) send(ctx context.Context, res *SearchSingleResult) bool {
    select {
    case r.ch <- res:
        return true
    case <-ctx.Done():
        return false
    }
}
```

Sends whose purpose is to deliver a result check the return value and `return` when it's `false` (the consumer is gone). Best-effort final sends that are immediately followed by `return` are ignored, as documented on `send`. I also documented that cancellation isn't reported as an error: `Err()` returns nil on a canceled search, same as on normal completion, because the producer just closes the channel on its way out.

## Testing

Added `TestSearchAsyncCancelUnblocksProducer`, which drives the leaking path that existing cancellation tests never reached: it fills a capacity-1 buffer with more results than the consumer drains, waits until the producer is actually parked on the send, then cancels and asserts the goroutine is gone. The prior test consumed every result before canceling, so the send never blocked and the leak couldn't surface.

## Disclosure on AI assistance

For transparency: the test and the text of this PR were written by an AI agent, and the root-cause analysis and fix were developed in collaboration with it. I reviewed all of it line by line and ran the suite locally. Happy to adjust or rewrite any part of the AI-assisted content if the maintainers prefer.

