### PR TITLE
fix: guard nil responseValue when parsing WhoAmI result

### DIFF
--- a/v3/whoami.go
+++ b/v3/whoami.go
@@ -19,5 +19,11 @@ func (l *Conn) WhoAmI(controls []Control) (*WhoAmIResult, error) {
 		return nil, err
 	}
 
-	return &WhoAmIResult{AuthzID: resp.Value.Data.String()}, nil
+	// responseValue is OPTIONAL (RFC 4532); Extended leaves Value nil when the
+	// server omits it. Guard the dereference and report an empty authzId.
+	result := &WhoAmIResult{}
+	if resp.Value != nil {
+		result.AuthzID = resp.Value.Data.String()
+	}
+	return result, nil
 }

--- a/v3/whoami_test.go
+++ b/v3/whoami_test.go
@@ -3,6 +3,7 @@ package ldap
 import (
 	"testing"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +25,39 @@ func TestConn_WhoAmI(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "dn:cn=admin,"+baseDN, result.AuthzID)
 	})
+}
+
+// TestWhoAmIResponseValueOmitted feeds a successful WhoAmI ExtendedResponse that
+// omits the optional responseValue [11]. A conformant server may leave it out;
+// WhoAmI must not panic dereferencing a nil Value, and AuthzID is empty when the
+// server sends no value.
+func TestWhoAmIResponseValueOmitted(t *testing.T) {
+	ptc := newPacketTranslatorConn()
+	defer func() { _ = ptc.Close() }()
+
+	conn := NewConn(ptc, false)
+	conn.Start()
+	defer func() { _ = conn.Close() }()
+
+	go func() {
+		req, err := ptc.ReceiveRequest()
+		if err != nil {
+			return
+		}
+		msgID := req.Children[0].Value.(int64)
+
+		resp := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+		resp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, msgID, "MessageID"))
+		extResp := ber.Encode(ber.ClassApplication, ber.TypeConstructed, ApplicationExtendedResponse, nil, "Extended Response")
+		extResp.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, 0, "resultCode"))
+		extResp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "matchedDN"))
+		extResp.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "diagnosticMessage"))
+		// responseValue [11] intentionally omitted.
+		resp.AppendChild(extResp)
+		_ = ptc.SendResponse(resp)
+	}()
+
+	result, err := conn.WhoAmI(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "", result.AuthzID)
 }


### PR DESCRIPTION
## Summary
`WhoAmI` dereferenced `resp.Value` unconditionally, but `Extended` leaves `ExtendedResponse.Value` nil when the server omits the optional `responseValue` (RFC 4532, `responseValue [11] OCTET STRING OPTIONAL`). A conformant server that omits it panics the caller with a nil-pointer dereference.

## Fix
Guard the dereference; return an empty `AuthzID` when the value is absent.

## Test
`TestWhoAmIResponseValueOmitted` uses the in-process `newPacketTranslatorConn` harness (no live server) to feed a successful WhoAmI response with no `responseValue`. It panics at `whoami.go` before the fix and passes after.

Found during a review of the unreleased commits since v3.4.13; fixing before the next tag closes it before it ships.