### PR TITLE
fix: guard constructed-form attributeType in server-side sort decode

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -980,7 +980,12 @@ func NewControlServerSideSorting(value *ber.Packet) (*ControlServerSideSorting, 
 		for _, child := range sequence.Children {
 			switch {
 			case child.ClassType == ber.ClassUniversal && child.Tag == ber.TagOctetString:
-				sortKey.AttributeType = child.Value.(string)
+				// A constructed-form OCTET STRING matches this case but leaves
+				// Value nil; guard the assertion so a malformed attributeType is
+				// rejected below rather than panicking.
+				if attrType, ok := child.Value.(string); ok {
+					sortKey.AttributeType = attrType
+				}
 
 			case child.ClassType == ber.ClassContext && child.Tag == 0:
 				sortKey.MatchingRule = child.Data.String()

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -425,6 +425,26 @@ func TestControlServerSideSortingDecoding(t *testing.T) {
 	}
 }
 
+// TestControlServerSideSortingConstructedAttributeType feeds a SortKey whose
+// attributeType is a constructed-form OCTET STRING. BER leaves such a packet's
+// Value nil, so the decoder's type assertion must be guarded: decoding must not
+// panic, and the missing primitive attributeType is reported as an error.
+func TestControlServerSideSortingConstructedAttributeType(t *testing.T) {
+	sortKey := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "SortKey")
+	// Constructed OCTET STRING: matches the ClassUniversal/TagOctetString case in
+	// the decoder but carries no primitive string Value.
+	sortKey.AppendChild(ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagOctetString, nil, "attributeType"))
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "SortKeyList")
+	seq.AppendChild(sortKey)
+
+	value := ber.Encode(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, nil, "Control Value")
+	value.Data.Write(seq.Bytes())
+
+	if _, err := NewControlServerSideSorting(value); err == nil {
+		t.Fatal("expected error for constructed-form attributeType, got nil")
+	}
+}
+
 func TestControlServerSideSortingResultDecoding(t *testing.T) {
 	for _, code := range ControlServerSideSortingCodes {
 		control := &ControlServerSideSortingResult{Result: code}


### PR DESCRIPTION
## Summary
`NewControlServerSideSorting` asserted `child.Value.(string)` without a comma-ok. A constructed-form OCTET STRING `attributeType` matches the `ClassUniversal`/`TagOctetString` case but leaves `Value` nil, so the assertion panics the decoder on malformed/hostile input.

## Fix
Comma-ok the assertion. A missing primitive `attributeType` now falls through to the existing `attributeType is missing` error instead of panicking.

## Test
`TestControlServerSideSortingConstructedAttributeType` feeds a constructed-form `attributeType`. It panics at `control.go` before the fix and returns the expected error after.

Follow-up to the hardening in #593, which left this sibling assertion unguarded. Found during a review of the unreleased commits since v3.4.13.