### PR TITLE
bump Go to 1.26/1.27 in CI and update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,14 +22,14 @@ jobs:
           fuzz-seconds: 300
           output-sarif: true
       - name: Upload Crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         if: failure() && steps.build.outcome == 'success'
         with:
           name: artifacts
           path: ./out/artifacts
       - name: Upload Sarif
         if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: false
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.26", "1.25"]
+        go: ["1.27", "1.26"]
         directory: ["./v3"]
     name: Go ${{ matrix.go }}.x PR Validate ${{ matrix.directory }} (Modules)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go }}
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-ldap/ldap/v3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Azure/go-ntlmssp v0.1.1


### PR DESCRIPTION
Go 1.27 has been released, so this updates the CI matrix and the module's Go directive to follow the currently supported Go versions.

* https://go.dev/blog/go1.27

### Changes
  
* `v3/go.mod`: bump the `go` directive from `1.25.0` to `1.26.0`
* `pr.yml`: test against Go 1.27 and 1.26 (was 1.26 and 1.25)
* `lint.yml`: run golangci-lint with Go 1.26 (was 1.25), and move `actions/checkout` before `actions/setup-go` so the repository is present when Go is set up
* Update actions to their latest major versions:
    * `actions/checkout` v4 -> v7
    * `actions/setup-go` v5 -> v7
    * `actions/upload-artifact` v3 -> v7 (v3 is no longer supported)
    * `github/codeql-action/upload-sarif` v2 -> v4

### Notes

Bumping the `go` directive to `1.26.0` means Go 1.25 is no longer supported by this module. This follows the Go release policy of supporting the two most recent major releases, which the CI matrix already reflects.