### PR TITLE
fix: identify RFC 4533 sync control members by tag, not by count

### DIFF
--- a/v3/control.go
+++ b/v3/control.go
@@ -1305,19 +1305,30 @@ type ControlSyncDone struct {
 	RefreshDeletes bool
 }
 
+// parseSyncMembers identifies the members of an RFC 4533 sync sequence by tag.
+// cookie is OPTIONAL and the flags carry a DEFAULT, so a member's position is not
+// fixed and the count of present members does not identify them.
+func parseSyncMembers(children []*ber.Packet) (cookie []byte, flag *bool, uuidSet *ber.Packet) {
+	for _, child := range children {
+		switch child.Tag {
+		case ber.TagOctetString:
+			cookie = child.ByteValue
+		case ber.TagBoolean:
+			if b, ok := child.Value.(bool); ok {
+				flag = &b
+			}
+		case ber.TagSet:
+			uuidSet = child
+		}
+	}
+	return cookie, flag, uuidSet
+}
+
 func NewControlSyncDone(pkt *ber.Packet) (*ControlSyncDone, error) {
-	var (
-		cookie         []byte
-		refreshDeletes bool
-	)
-	switch len(pkt.Children) {
-	case 0:
-		// have nothing to do
-	case 1:
-		cookie = pkt.Children[0].ByteValue
-	case 2:
-		cookie = pkt.Children[0].ByteValue
-		refreshDeletes = pkt.Children[1].Value.(bool)
+	var refreshDeletes bool
+	cookie, flag, _ := parseSyncMembers(pkt.Children)
+	if flag != nil {
+		refreshDeletes = *flag
 	}
 	return &ControlSyncDone{
 		Criticality:    false,
@@ -1430,7 +1441,6 @@ type ControlSyncInfo struct {
 
 func NewControlSyncInfo(pkt *ber.Packet) (*ControlSyncInfo, error) {
 	var (
-		cookie         []byte
 		refreshDone    = true
 		refreshDeletes bool
 		syncUUIDs      []uuid.UUID
@@ -1444,14 +1454,9 @@ func NewControlSyncInfo(pkt *ber.Packet) (*ControlSyncInfo, error) {
 		}
 	case SyncInfoRefreshDelete:
 		c.Value = SyncInfoRefreshDelete
-		switch len(pkt.Children) {
-		case 0:
-			// have nothing to do
-		case 1:
-			cookie = pkt.Children[0].ByteValue
-		case 2:
-			cookie = pkt.Children[0].ByteValue
-			refreshDone = pkt.Children[1].Value.(bool)
+		cookie, flag, _ := parseSyncMembers(pkt.Children)
+		if flag != nil {
+			refreshDone = *flag
 		}
 		c.RefreshDelete = &ControlSyncInfoRefreshDelete{
 			Cookie:      cookie,
@@ -1459,14 +1464,9 @@ func NewControlSyncInfo(pkt *ber.Packet) (*ControlSyncInfo, error) {
 		}
 	case SyncInfoRefreshPresent:
 		c.Value = SyncInfoRefreshPresent
-		switch len(pkt.Children) {
-		case 0:
-			// have nothing to do
-		case 1:
-			cookie = pkt.Children[0].ByteValue
-		case 2:
-			cookie = pkt.Children[0].ByteValue
-			refreshDone = pkt.Children[1].Value.(bool)
+		cookie, flag, _ := parseSyncMembers(pkt.Children)
+		if flag != nil {
+			refreshDone = *flag
 		}
 		c.RefreshPresent = &ControlSyncInfoRefreshPresent{
 			Cookie:      cookie,
@@ -1474,19 +1474,13 @@ func NewControlSyncInfo(pkt *ber.Packet) (*ControlSyncInfo, error) {
 		}
 	case SyncInfoSyncIdSet:
 		c.Value = SyncInfoSyncIdSet
-		switch len(pkt.Children) {
-		case 0:
-			// have nothing to do
-		case 1:
-			cookie = pkt.Children[0].ByteValue
-		case 2:
-			cookie = pkt.Children[0].ByteValue
-			refreshDeletes = pkt.Children[1].Value.(bool)
-		case 3:
-			cookie = pkt.Children[0].ByteValue
-			refreshDeletes = pkt.Children[1].Value.(bool)
-			syncUUIDs = make([]uuid.UUID, 0, len(pkt.Children[2].Children))
-			for _, child := range pkt.Children[2].Children {
+		cookie, flag, uuidSet := parseSyncMembers(pkt.Children)
+		if flag != nil {
+			refreshDeletes = *flag
+		}
+		if uuidSet != nil {
+			syncUUIDs = make([]uuid.UUID, 0, len(uuidSet.Children))
+			for _, child := range uuidSet.Children {
 				u, err := uuid.FromBytes(child.ByteValue)
 				if err != nil {
 					return nil, fmt.Errorf("failed to decode uuid: %w", err)

--- a/v3/control_test.go
+++ b/v3/control_test.go
@@ -459,3 +459,131 @@ func TestControlServerSideSortingResultDecoding(t *testing.T) {
 		}
 	}
 }
+
+var syncTestUUID = []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00}
+
+func syncUUIDSet(t *testing.T) *ber.Packet {
+	t.Helper()
+	set := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSet, nil, "syncUUIDs")
+	set.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, string(syncTestUUID), "syncUUID"))
+	return set
+}
+
+func syncInfoPacket(t *testing.T, tag ber.Tag, children ...*ber.Packet) *ber.Packet {
+	t.Helper()
+	seq := ber.Encode(ber.ClassContext, ber.TypeConstructed, tag, nil, "syncInfoValue")
+	for _, child := range children {
+		seq.AppendChild(child)
+	}
+	return ber.DecodePacket(seq.Bytes())
+}
+
+func syncBool(v bool, desc string) *ber.Packet {
+	return ber.NewBoolean(ber.ClassUniversal, ber.TypePrimitive, ber.TagBoolean, v, desc)
+}
+
+func syncCookie(v string) *ber.Packet {
+	return ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, v, "cookie")
+}
+
+// RFC 4533 2.5: syncIdSet ::= SEQUENCE { cookie OPTIONAL, refreshDeletes DEFAULT FALSE, syncUUIDs }.
+func TestControlSyncInfoSyncIdSetOptionalCookie(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		children       []*ber.Packet
+		wantCookie     string
+		wantRefreshDel bool
+	}{
+		{"cookie omitted", []*ber.Packet{syncBool(true, "refreshDeletes"), syncUUIDSet(t)}, "", true},
+		{"cookie and refreshDeletes omitted", []*ber.Packet{syncUUIDSet(t)}, "", false},
+		{"all members present", []*ber.Packet{syncCookie("csn=1"), syncBool(true, "refreshDeletes"), syncUUIDSet(t)}, "csn=1", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := NewControlSyncInfo(syncInfoPacket(t, ber.Tag(SyncInfoSyncIdSet), tc.children...))
+			if err != nil {
+				t.Fatalf("NewControlSyncInfo: %v", err)
+			}
+			if got := string(c.SyncIdSet.Cookie); got != tc.wantCookie {
+				t.Errorf("Cookie = %q, want %q", got, tc.wantCookie)
+			}
+			if c.SyncIdSet.RefreshDeletes != tc.wantRefreshDel {
+				t.Errorf("RefreshDeletes = %v, want %v", c.SyncIdSet.RefreshDeletes, tc.wantRefreshDel)
+			}
+			if len(c.SyncIdSet.SyncUUIDs) != 1 {
+				t.Fatalf("SyncUUIDs = %v, want 1 entry", c.SyncIdSet.SyncUUIDs)
+			}
+			if !bytes.Equal(c.SyncIdSet.SyncUUIDs[0][:], syncTestUUID) {
+				t.Errorf("SyncUUIDs[0] = %v, want %v", c.SyncIdSet.SyncUUIDs[0], syncTestUUID)
+			}
+		})
+	}
+}
+
+// RFC 4533 2.5: refreshDelete/refreshPresent ::= SEQUENCE { cookie OPTIONAL, refreshDone DEFAULT TRUE }.
+func TestControlSyncInfoRefreshOptionalCookie(t *testing.T) {
+	pkt := syncInfoPacket(t, ber.Tag(SyncInfoRefreshPresent), syncBool(false, "refreshDone"))
+	c, err := NewControlSyncInfo(pkt)
+	if err != nil {
+		t.Fatalf("NewControlSyncInfo: %v", err)
+	}
+	if len(c.RefreshPresent.Cookie) != 0 {
+		t.Errorf("Cookie = %q, want empty", c.RefreshPresent.Cookie)
+	}
+	if c.RefreshPresent.RefreshDone {
+		t.Error("RefreshDone = true, want false")
+	}
+
+	pkt = syncInfoPacket(t, ber.Tag(SyncInfoRefreshDelete), syncBool(false, "refreshDone"))
+	c, err = NewControlSyncInfo(pkt)
+	if err != nil {
+		t.Fatalf("NewControlSyncInfo: %v", err)
+	}
+	if len(c.RefreshDelete.Cookie) != 0 {
+		t.Errorf("Cookie = %q, want empty", c.RefreshDelete.Cookie)
+	}
+	if c.RefreshDelete.RefreshDone {
+		t.Error("RefreshDone = true, want false")
+	}
+
+	pkt = syncInfoPacket(t, ber.Tag(SyncInfoRefreshDelete), syncCookie("csn=2"), syncBool(false, "refreshDone"))
+	c, err = NewControlSyncInfo(pkt)
+	if err != nil {
+		t.Fatalf("NewControlSyncInfo: %v", err)
+	}
+	if string(c.RefreshDelete.Cookie) != "csn=2" {
+		t.Errorf("Cookie = %q, want %q", c.RefreshDelete.Cookie, "csn=2")
+	}
+	if c.RefreshDelete.RefreshDone {
+		t.Error("RefreshDone = true, want false")
+	}
+}
+
+// RFC 4533 2.4: syncDoneValue ::= SEQUENCE { cookie OPTIONAL, refreshDeletes DEFAULT FALSE }.
+func TestControlSyncDoneOptionalCookie(t *testing.T) {
+	seq := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "syncDoneValue")
+	seq.AppendChild(syncBool(true, "refreshDeletes"))
+	c, err := NewControlSyncDone(ber.DecodePacket(seq.Bytes()))
+	if err != nil {
+		t.Fatalf("NewControlSyncDone: %v", err)
+	}
+	if len(c.Cookie) != 0 {
+		t.Errorf("Cookie = %q, want empty", c.Cookie)
+	}
+	if !c.RefreshDeletes {
+		t.Error("RefreshDeletes = false, want true")
+	}
+}
+
+// syncUUIDs is mandatory; a server omitting it must not crash the decoder.
+func TestControlSyncInfoSyncIdSetWithoutUUIDs(t *testing.T) {
+	c, err := NewControlSyncInfo(syncInfoPacket(t, ber.Tag(SyncInfoSyncIdSet), syncCookie("csn=3")))
+	if err != nil {
+		t.Fatalf("NewControlSyncInfo: %v", err)
+	}
+	if string(c.SyncIdSet.Cookie) != "csn=3" {
+		t.Errorf("Cookie = %q, want %q", c.SyncIdSet.Cookie, "csn=3")
+	}
+	if len(c.SyncIdSet.SyncUUIDs) != 0 {
+		t.Errorf("SyncUUIDs = %v, want none", c.SyncIdSet.SyncUUIDs)
+	}
+}


### PR DESCRIPTION
## On disclosure, first

I read `SECURITY.md` before opening this. I am sending it as a normal PR because the repository's own precedent for this exact class is public PRs -- #611, #612, #614 (guarding malformed decode input), and #617 and #618, both of which you authored. #617's description says in as many words that "a conformant server that omits it panics the caller with a nil-pointer dereference". If you would rather have had this privately, say so and I will close this immediately and resend it to the addresses in `SECURITY.md`.

## The bug

`NewControlSyncDone` and `NewControlSyncInfo` decode RFC 4533 sync sequences by switching on `len(pkt.Children)` and treating `Children[0]` as the cookie. RFC 4533 §2.4/§2.5 mark `cookie` as `OPTIONAL` and the refresh flags as `DEFAULT`, so the number of members present does not identify which members they are.

With the cookie omitted:

| control | current result |
|---|---|
| `syncIdSet` | **panic** -- `Children[1]` is the `SET`, whose `Value` is nil, and `Children[1].Value.(bool)` asserts on it |
| `syncIdSet`, flags also omitted | every UUID silently dropped |
| `refreshDelete` / `refreshPresent` | the boolean is read as the cookie, and `refreshDone` comes out **inverted** |
| `syncDone` | `Cookie` gets the flag's byte, `RefreshDeletes` is lost |

```
--- FAIL: TestControlSyncInfoSyncIdSetOptionalCookie/cookie_omitted
panic: interface conversion: interface {} is nil, not bool
	github.com/go-ldap/ldap/v3.NewControlSyncInfo(...) v3/control.go:1484
```

```
Cookie = "\x00", want empty
RefreshDone = true, want false
Cookie = "\x01", want empty
RefreshDeletes = false, want true
```

All reproduced through the exported constructors, no network.

## Your own `NewControlServerSideSorting` already does this

`v3/control.go:961` decodes the same shape -- a SEQUENCE with OPTIONAL and context-tagged members -- by iterating children and switching on `ClassType`/`Tag`, and it guards the type assertion:

```go
// A constructed-form OCTET STRING matches this case but leaves
// Value nil; guard the assertion so a malformed attributeType is
// rejected below rather than panicking.
if attrType, ok := child.Value.(string); ok {
```

That comment describes the exact failure in `NewControlSyncInfo`, and it is your #618. This change applies the same shape to the sync controls: one `parseSyncMembers` helper that dispatches on tag, with the boolean assertion guarded.

## What I did not change

`NewControlSyncState` (`v3/control.go:1246`) also switches on the child count, and it is **correct** -- there the cookie is the trailing optional, so position is unambiguous. I left it alone rather than churn it.

## Verification

`gofmt -l .` clean, `go vet .` clean -- CI runs exactly those, then `go test -v -cover -race -count=1 .`. The offline half of that suite: `ok github.com/go-ldap/ldap/v3` on both master and this branch, coverage 32.3% either way. I did not run the integration half, which needs `make local-server` and a Docker OpenLDAP; the network tests hang in my sandbox and I would rather say so than imply I ran them.

There was **no test coverage at all** for these constructors before this -- `grep` for `NewControlSyncInfo|NewControlSyncDone|SyncInfo` in `*_test.go` returns nothing -- which is why this went unnoticed. The new tests include an `all_members_present` row that passes on both sides, as a regression guard on the path that already worked.

I mutation-checked each site separately, anchored to its own `case` block since several are textual twins. All eight fail when weakened:

| mutation | result |
|---|---|
| cookie case tag | `Cookie = "", want "csn=1"` |
| drop the boolean capture | `RefreshDeletes = false, want true` |
| uuid set case tag | `SyncUUIDs = [], want 1 entry` |
| syncDone flag apply | `RefreshDeletes = false, want true` |
| refreshDelete flag | `RefreshDone = true, want false` |
| refreshPresent flag | `RefreshDone = true, want false` |
| syncIdSet flag | `RefreshDeletes = false, want true` |
| uuidSet nil guard | `panic: nil pointer dereference` |

Two notes on that, because both changed the diff:

- A ninth mutation **survived** -- a `if child.ClassType != ber.ClassUniversal { continue }` guard I had copied from the sorting sibling. It is load-bearing there (`SortKey` really does have context-tagged members) but unreachable here, since no `syncInfoValue` member is context-tagged. I removed those lines rather than ship code no test can pin.
- The `uuidSet` nil guard also survived at first. That one I kept and covered instead, with `TestControlSyncInfoSyncIdSetWithoutUUIDs`, because a server omitting the mandatory `syncUUIDs` would otherwise nil-deref.

## Observable output

Identical for every input the old code handled -- the `all_members_present` row passes unmodified on both sides. It changes only the cases that were wrong. No existing test row had to change, since there were none.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
