### PR TITLE
Expose ResultCode and DiagnosticMessage on SearchResult

### DIFF
--- a/v3/error.go
+++ b/v3/error.go
@@ -195,6 +195,46 @@ func (e *Error) Error() string {
 
 func (e *Error) Unwrap() error { return e.Err }
 
+// ParseLDAPResult extracts resultCode, matchedDN, and diagnosticMessage from a
+// BER packet representing an LDAPResult (e.g. SearchResultDone).
+//
+// Unlike GetLDAPError, ParseLDAPResult does not return early when resultCode is
+// success (0). This allows callers to read the diagnosticMessage even on a
+// successful operation, which some servers use to signal warnings or degraded
+// state (for example, a directory in read-only / reinitializing mode).
+func ParseLDAPResult(packet *ber.Packet) (resultCode uint16, matchedDN, diagnosticMessage string) {
+	if packet == nil || len(packet.Children) < 2 || packet.Children[1] == nil {
+		return 0, "", ""
+	}
+	response := packet.Children[1]
+	if len(response.Children) < 1 || response.Children[0] == nil || response.Children[0].Value == nil {
+		return 0, "", ""
+	}
+	switch v := response.Children[0].Value.(type) {
+	case int64:
+		resultCode = uint16(v)
+	case uint64:
+		resultCode = uint16(v)
+	case int:
+		resultCode = uint16(v)
+	default:
+		return 0, "", ""
+	}
+	if len(response.Children) >= 2 && response.Children[1] != nil {
+		if s, ok := response.Children[1].Value.(string); ok {
+			matchedDN = s
+		}
+	}
+	if len(response.Children) >= 3 && response.Children[2] != nil && response.Children[2].Value != nil {
+		if s, ok := response.Children[2].Value.(string); ok {
+			diagnosticMessage = s
+		} else {
+			diagnosticMessage = fmt.Sprintf("%v", response.Children[2].Value)
+		}
+	}
+	return resultCode, matchedDN, diagnosticMessage
+}
+
 // GetLDAPError creates an Error out of a BER packet representing a LDAPResult
 // The return is an error object. It can be casted to a Error structure.
 // This function returns nil if resultCode in the LDAPResult sequence is success(0).

--- a/v3/search.go
+++ b/v3/search.go
@@ -377,6 +377,14 @@ type SearchResult struct {
 	Referrals []string
 	// Controls are the returned controls
 	Controls []Control
+	// ResultCode is the LDAP resultCode from SearchResultDone (0 = success).
+	// Populated even on success so callers can inspect it alongside DiagnosticMessage.
+	ResultCode uint16
+	// DiagnosticMessage is the server's free-text message from SearchResultDone.
+	// Per RFC 4511, this may be set even when resultCode is 0 (success).
+	// GetLDAPError returns nil on success and does not expose this field;
+	// it is preserved here so callers can log or act on it.
+	DiagnosticMessage string
 }
 
 // Print outputs a human-readable description
@@ -398,6 +406,8 @@ func (s *SearchResult) appendTo(r *SearchResult) {
 	r.Entries = append(r.Entries, s.Entries...)
 	r.Referrals = append(r.Referrals, s.Referrals...)
 	r.Controls = append(r.Controls, s.Controls...)
+	r.ResultCode = s.ResultCode
+	r.DiagnosticMessage = s.DiagnosticMessage
 }
 
 // SearchSingleResult holds the server's single entry response to a search request
@@ -601,6 +611,7 @@ func (l *Conn) Search(searchRequest *SearchRequest) (*SearchResult, error) {
 			}
 			result.Entries = append(result.Entries, entry)
 		case 5:
+			result.ResultCode, _, result.DiagnosticMessage = ParseLDAPResult(packet)
 			err := GetLDAPError(packet)
 			if err != nil {
 				return result, err


### PR DESCRIPTION
## Problem

`GetLDAPError` returns `nil` when `resultCode` is 0 (success), discarding
the `diagnosticMessage` from `SearchResultDone`. Per RFC 4511 §4.1.9, servers
may set `diagnosticMessage` even on a successful operation to communicate
additional information such as degraded state.

For example, Red Hat IPA sets `diagnosticMessage` when the directory is
reinitializing but still returns `resultCode` 0 with an empty entry list.
Callers of `Search()` currently have no way to see that message — they only
see zero entries and no error, which is indistinguishable from a genuine
empty result.

## Solution

- Add `ResultCode` and `DiagnosticMessage` fields to `SearchResult`.
- In `Search()`, populate them from the `SearchResultDone` packet (case 5) **before** calling `GetLDAPError`, so they are preserved even when`GetLDAPError` returns `nil` on success.
- Add `ParseLDAPResult` helper that extracts `resultCode`, `matchedDN`, and `diagnosticMessage` from an `LDAPResult` BER packet without the early return on success that `GetLDAPError` has.
- Copy the new fields in `appendTo` so paged searches preserve them.

## Backward compatibility

- `GetLDAPError` is unchanged.
- `SearchResult` is a struct; adding fields is backward compatible in Go.
- Existing callers are unaffected — they never read the new fields.
- Callers who need the diagnostic on success can now read `result.DiagnosticMessage` after `Search()` returns.

## References

- [RFC 4511 §4.1.9](https://datatracker.ietf.org/doc/html/rfc4511#section-4.1.9) — LDAPResult definition (resultCode + diagnosticMessage)
- [RFC 4511 §4.5.2](https://datatracker.ietf.org/doc/html/rfc4511#section-4.5.2) — SearchResultDone is an LDAPResult